### PR TITLE
Add wheel for cosa2

### DIFF
--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -1,10 +1,9 @@
 name: Python Wheels
 
-#on:
-#  push:
-#    tags:
-#      - '*'
-on: [push]
+on:
+  push:
+    tags:
+      - '*'
 
 jobs:
   build:
@@ -48,6 +47,6 @@ jobs:
           echo repository=https://upload.pypi.org/legacy/  >> ~/.pypirc
           echo username=makaim                             >> ~/.pypirc
           echo password=$PYPI_PASSWORD                     >> ~/.pypirc
-          # twine upload --config-file ~/.pypirc --skip-existing wheelhouse/*
+          twine upload --config-file ~/.pypirc --skip-existing wheelhouse/*
       env:
           PYPI_PASSWORD: ${{ secrets.PYPI_PASSWORD }}

--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -1,0 +1,53 @@
+name: Python Wheels
+
+on:
+  push:
+    tags:
+      - '*'
+
+
+jobs:
+  build:
+
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        python-version: [35, 36, 37, 38]
+
+    steps:
+    - uses: actions/checkout@v2
+    - name: Checkout submodules
+      shell: bash
+      run: |
+        auth_header="$(git config --local --get http.https://github.com/.extraheader)"
+        git submodule sync --recursive
+        git -c "http.extraheader=$auth_header" -c protocol.version=2 submodule update --init --force --recursive --depth=1
+    - name: Build wheels
+      shell: bash
+      run: |
+          docker run --mount type=bind,source="$(pwd)"/../cosa2,target=/cosa2 keyiz/manylinux-java:py${{ matrix.python-version }} /cosa2/contrib/wheels/ci.sh
+      env:
+        PY_VERSION: ${{ matrix.python-version }}
+    - uses: actions/upload-artifact@v1
+      with:
+        name: py${{ matrix.python-version }} wheel
+        path: wheelhouse/
+    - name: Installing Python packages
+      shell: bash
+      run: |
+          sudo pip3 install setuptools
+          sudo pip3 install twine
+    - name: Uploading to PyPi
+      shell: bash
+      run: |
+          echo [distutils]                                  > ~/.pypirc
+          echo index-servers =                             >> ~/.pypirc
+          echo "  pypi"                                    >> ~/.pypirc
+          echo                                             >> ~/.pypirc
+          echo [pypi]                                      >> ~/.pypirc
+          echo repository=https://upload.pypi.org/legacy/  >> ~/.pypirc
+          echo username=makaim                             >> ~/.pypirc
+          echo password=$PYPI_PASSWORD                     >> ~/.pypirc
+          twine upload --config-file ~/.pypirc --skip-existing wheelhouse/*
+      env:
+          PYPI_PASSWORD: ${{ secrets.PYPI_PASSWORD }}

--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -1,10 +1,10 @@
 name: Python Wheels
 
-on:
-  push:
-    tags:
-      - '*'
-
+#on:
+#  push:
+#    tags:
+#      - '*'
+on: [push]
 
 jobs:
   build:
@@ -48,6 +48,6 @@ jobs:
           echo repository=https://upload.pypi.org/legacy/  >> ~/.pypirc
           echo username=makaim                             >> ~/.pypirc
           echo password=$PYPI_PASSWORD                     >> ~/.pypirc
-          twine upload --config-file ~/.pypirc --skip-existing wheelhouse/*
+          # twine upload --config-file ~/.pypirc --skip-existing wheelhouse/*
       env:
           PYPI_PASSWORD: ${{ secrets.PYPI_PASSWORD }}

--- a/contrib/wheels/build_wheel.py
+++ b/contrib/wheels/build_wheel.py
@@ -1,0 +1,111 @@
+import os
+import re
+import sys
+import platform
+import subprocess
+import multiprocessing
+import shutil
+import glob
+
+from setuptools import setup, Extension
+from setuptools.command.build_ext import build_ext
+from distutils.version import LooseVersion
+
+
+class CMakeExtension(Extension):
+    def __init__(self, name, sourcedir=''):
+        Extension.__init__(self, name, sources=[])
+        self.sourcedir = os.path.abspath(sourcedir)
+
+
+class CMakeBuild(build_ext):
+    def run(self):
+        try:
+            out = subprocess.check_output(['cmake', '--version'])
+        except OSError:
+            raise RuntimeError(
+                "CMake must be installed to build the following extensions: " +
+                ", ".join(e.name for e in self.extensions))
+
+        if self.is_windows():
+            cmake_version = LooseVersion(
+                re.search(r'version\s*([\d.]+)', out.decode()).group(1))
+            if cmake_version < '3.1.0':
+                raise RuntimeError("CMake >= 3.1.0 is required on Windows")
+
+        for ext in self.extensions:
+            self.build_extension(ext)
+
+    @staticmethod
+    def is_windows():
+        tag = platform.system().lower()
+        return tag == "windows"
+
+    @staticmethod
+    def is_linux():
+        tag = platform.system().lower()
+        return tag == "linux"
+
+    def build_extension(self, ext):
+        extdir = os.path.abspath(
+            os.path.dirname(self.get_ext_fullpath(ext.name)))
+        if not os.path.isdir(extdir):
+            os.makedirs(extdir)
+
+        cfg = 'Release'
+        build_args = ['--config', cfg]
+
+        cpu_count = max(2, multiprocessing.cpu_count() // 2)
+        build_args += ['--', '-j{0}'.format(cpu_count)]
+
+        # contrib folder
+        contrib_path = os.path.dirname(os.path.dirname(os.path.realpath(__file__)))
+        # build smt-switch
+        contrib_smt_switch = os.path.join(contrib_path, "setup-smt-switch.sh")
+        subprocess.check_call(contrib_smt_switch)
+        # build btor2
+        contrib_btor2 = os.path.join(contrib_path, "setup-btor2tools.sh")
+        subprocess.check_call(contrib_btor2)
+
+        # configure
+        root_dir = os.path.dirname(contrib_path)
+        build_dir = os.path.join(root_dir, "build")
+        # to avoid multiple build, only call reconfigure if we couldn't find the makefile
+        # for python
+        python_make_dir = os.path.join(build_dir, "python")
+        if not os.path.isfile(os.path.join(python_make_dir, "Makefile")):
+            configure_path = os.path.join(root_dir, "configure.sh")
+            configure_args = [configure_path, "--python"]
+            subprocess.check_call(configure_args, cwd=root_dir)
+
+        # build the main library
+        subprocess.check_call(
+            ['cmake', '--build', '.', "--target", "cosa2"] + build_args, cwd=build_dir)
+        # build the python binding
+        python_build_dir = os.path.join(build_dir, "python")
+        subprocess.check_call(["make"], cwd=python_build_dir)
+        # the build folder gets cleaned during the config, need to create it again
+        # this is necessary since "build" is a python dist folder
+        if not os.path.isdir(extdir):
+            os.mkdir(extdir)
+
+        for lib_filename in glob.glob(os.path.join(python_build_dir, "pycosa2.*")):
+            if os.path.splitext(lib_filename)[1] == ".cxx":
+                continue
+            dst_filename = os.path.join(extdir, os.path.basename(lib_filename))
+            shutil.copy(lib_filename, dst_filename)
+
+
+setup(
+    name='cosa2',
+    version='0.1.0',
+    author='Makai Mann',
+    ext_modules=[CMakeExtension('cosa2')],
+    cmdclass=dict(build_ext=CMakeBuild),
+    long_description='python bindings for the next generation cosa',
+    url='https://github.com/upscale-project/cosa2',
+    license='BSD',
+    tests_require=['pytest'],
+    zip_safe=False,
+)
+

--- a/contrib/wheels/ci.sh
+++ b/contrib/wheels/ci.sh
@@ -1,0 +1,9 @@
+#!/usr/bin/env bash
+set -e
+
+cd cosa2/
+mkdir -p build
+pip install Cython==0.29
+python contrib/wheels/build_wheel.py bdist_wheel
+auditwheel show dist/*
+auditwheel repair dist/*


### PR DESCRIPTION
This follows the similar PR as https://github.com/makaimann/smt-switch/pull/40

Somehow I still got the binary mismatch even after building `smt-switch` from scratch. It could be some version mismatch on my side. To build the wheel, do
```
python contrib/wheels/build_wheel.py bdist_wheel
```
A wheel will appear in the `dist/` folder.

Also it seems like `smt-switch` has to be installed as well. I'd suggest adding `smt-switch` as a dependency to the `build_wheel.py`.

EDIT:
Some python tools don't like package name and module name mismatch. In this case, we have `pycosa2` as module name and `cosa2` as package name. I'm leaning towards renaming `pycosa2` to `cosa2`.