### PR TITLE
VCD Trace Dump

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -37,6 +37,7 @@ add_library(cosa2
   "${PROJECT_SOURCE_DIR}/engines/kinduction.cpp"
   "${PROJECT_SOURCE_DIR}/utils/logger.cpp"
   "${PROJECT_SOURCE_DIR}/utils/term_analysis.cpp"
+  "${PROJECT_SOURCE_DIR}/printers/vcd_witness_printer.cpp"
   )
 
 if (APPLE)

--- a/cosa2.cpp
+++ b/cosa2.cpp
@@ -32,6 +32,7 @@
 #include "interpolant.h"
 #include "kinduction.h"
 #include "printers/btor2_witness_printer.h"
+#include "printers/vcd_witness_printer.h"
 #include "prop.h"
 #include "utils/logger.h"
 
@@ -49,7 +50,8 @@ enum optionIndex
   ENGINE,
   BOUND,
   PROP,
-  VERBOSITY
+  VERBOSITY,
+  VCDNAME
 };
 
 struct Arg : public option::Arg
@@ -118,6 +120,12 @@ const option::Descriptor usage[] = {
     "verbosity",
     Arg::Numeric,
     "  --verbosity, -v \tVerbosity for printing to standard out." },
+  { VCDNAME,
+    0,
+    "",
+    "vcd",
+    Arg::NonEmpty,
+    "  --vcd \tName of Value Change Dump (VCD) if witness exists." },
   { 0, 0, 0, 0, 0, 0 }
 };
 /*********************************** end Option Handling setup
@@ -160,6 +168,7 @@ int main(int argc, char ** argv)
   unsigned int prop_idx = default_prop_idx;
   unsigned int bound = default_bound;
   unsigned int verbosity = default_verbosity;
+  std::string vcd_name;
 
   for (int i = 0; i < parse.optionsCount(); ++i) {
     option::Option & opt = buffer[i];
@@ -170,6 +179,7 @@ int main(int argc, char ** argv)
       case BOUND: bound = atoi(opt.arg); break;
       case PROP: prop_idx = atoi(opt.arg); break;
       case VERBOSITY: verbosity = atoi(opt.arg); break;
+      case VCDNAME: vcd_name = opt.arg; break;
       case UNKNOWN_OPTION:
         // not possible because Arg::Unknown returns ARG_ILLEGAL
         // which aborts the parse with an error
@@ -243,6 +253,10 @@ int main(int argc, char ** argv)
       vector<UnorderedTermMap> cex;
       if (prover->witness(cex)) {
         print_witness_btor(btor_enc, cex);
+        if (!vcd_name.empty()) {
+          VCDWitnessPrinter vcdprinter(btor_enc, fts);
+          vcdprinter.DumpTraceToFile(vcd_name, cex);
+        }
       }
       return 1;
     } else if (r == TRUE) {

--- a/cosa2.cpp
+++ b/cosa2.cpp
@@ -254,8 +254,8 @@ int main(int argc, char ** argv)
       if (prover->witness(cex)) {
         print_witness_btor(btor_enc, cex);
         if (!vcd_name.empty()) {
-          VCDWitnessPrinter vcdprinter(btor_enc, fts);
-          vcdprinter.DumpTraceToFile(vcd_name, cex);
+          VCDWitnessPrinter vcdprinter(btor_enc, fts, cex);
+          vcdprinter.DumpTraceToFile(vcd_name);
         }
       }
       return 1;

--- a/frontends/btor2_encoder.h
+++ b/frontends/btor2_encoder.h
@@ -40,6 +40,7 @@ class BTOR2Encoder
   BTOR2Encoder(std::string filename, TransitionSystem & ts)
       : ts_(ts), solver_(ts.solver())
   {
+    preprocess(filename);
     parse(filename);
   };
 
@@ -62,7 +63,9 @@ class BTOR2Encoder
   // takes a list of booleans / bitvectors of size one
   // and lazily converts them to the majority
   smt::TermVec lazy_convert(const smt::TermVec &) const;
-
+  
+  // preprocess a btor2 file
+  void preprocess(const std::string & filename);
   // parse a btor2 file
   void parse(const std::string filename);
 
@@ -75,6 +78,7 @@ class BTOR2Encoder
   smt::TermVec inputsvec_;
   smt::TermVec statesvec_;
   std::map<uint64_t, smt::Term> no_next_states_;
+  std::unordered_map<uint64_t, std::string> state_renaming_table;
 
   // Useful variables
   smt::Sort linesort_;

--- a/printers/vcd_witness_printer.cpp
+++ b/printers/vcd_witness_printer.cpp
@@ -154,25 +154,25 @@ VCDWitnessPrinter::VCDWitnessPrinter(const BTOR2Encoder & btor_enc,
 
   // you also need to figure out the indices used for each array
   // and dump these values when needed and dump the default value
-  logger.log(0, "-------------Input Dump-----------------");
+  logger.log(3, "-------------Input Dump-----------------");
   for (auto && i: inputs_) {
-    logger.log(0, "{}", i->to_string());
+    logger.log(3, "{}", i->to_string());
   }
-  logger.log(0, "-------------State Dump-----------------");
+  logger.log(3, "-------------State Dump-----------------");
   for (auto && s: states_) {
-    logger.log(0, "{}", s->to_string());
+    logger.log(3, "{}", s->to_string());
   }
-  logger.log(0, "-------------No Next States-----------------");
+  logger.log(3, "-------------No Next States-----------------");
   for (auto && s: no_next_states_) {
-    logger.log(0, "{}", s.second->to_string());
+    logger.log(3, "{}", s.second->to_string());
   }
 }
 
 void VCDWitnessPrinter::DebugDump(const std::vector<smt::UnorderedTermMap> & cex) const {
   for (uint64_t fidx = 0; fidx < cex.size(); ++ fidx) {
-    logger.log(0, "------------- CEX : F{} -----------------", fidx);
+    logger.log(3, "------------- CEX : F{} -----------------", fidx);
     for (auto && t : cex.at(fidx)) {
-      logger.log(0, "{} -> {}", t.first->to_string(), t.second->to_string() );
+      logger.log(3, "{} -> {}", t.first->to_string(), t.second->to_string() );
     }
   }
 }
@@ -333,6 +333,7 @@ void VCDWitnessPrinter::DumpTraceToFile(const std::string & vcd_file_name,
     throw CosaException("Unable to write to : " + vcd_file_name);
   GenHeader(fout);
   DumpValues(fout, cex);
+  logger.log(0, "Trace written to " + vcd_file_name);
 }
 
 } // namespace cosa

--- a/printers/vcd_witness_printer.cpp
+++ b/printers/vcd_witness_printer.cpp
@@ -383,11 +383,9 @@ void VCDWitnessPrinter::dump_all(const smt::UnorderedTermMap & valmap,
   for (auto && sig_bv_ptr : allsig_bv_) {
     auto pos = valmap.find(sig_bv_ptr->ast);
     if (pos == valmap.end()) {
-      logger.log(0, "missing value in provided trace @{}: {} ,{}, {}" ,
+      logger.log(0, "missing value in provided trace @{}: {}" ,
         t,
-        sig_bv_ptr->full_name,
-        sig_bv_ptr->hash, 
-        sig_bv_ptr->ast->to_string());
+        sig_bv_ptr->full_name);
       continue;
     }
     auto val = as_bits(pos->second->to_string());
@@ -401,10 +399,9 @@ void VCDWitnessPrinter::dump_all(const smt::UnorderedTermMap & valmap,
   for (auto && sig_array_ptr : allsig_array_) {
     auto pos = valmap.find(sig_array_ptr->ast);
     if (pos == valmap.end()) {
-      logger.log(0, "missing value in provided trace @{}: {} , {}" ,
+      logger.log(0, "missing value in provided trace @{}: {}" ,
         t,
-        sig_array_ptr->full_name,
-        sig_array_ptr->ast->to_string());
+        sig_array_ptr->full_name);
       continue;
     }
     smt::Term memvalue = pos->second;
@@ -453,11 +450,9 @@ void VCDWitnessPrinter::dump_diff(const smt::UnorderedTermMap & valmap,
   for (auto && sig_bv_ptr : allsig_bv_) {
     auto pos = valmap.find(sig_bv_ptr->ast);
     if (pos == valmap.end()) {
-      logger.log(0, "missing value in provided trace @{}: {} ,{}, {}" ,
+      logger.log(0, "missing value in provided trace @{}: {}" ,
         t,
-        sig_bv_ptr->full_name,
-        sig_bv_ptr->hash, 
-        sig_bv_ptr->ast->to_string());
+        sig_bv_ptr->full_name);
       continue;
     }
     auto val = as_bits(pos->second->to_string());
@@ -480,10 +475,9 @@ void VCDWitnessPrinter::dump_diff(const smt::UnorderedTermMap & valmap,
   for (auto && sig_array_ptr : allsig_array_) {
     auto pos = valmap.find(sig_array_ptr->ast);
     if (pos == valmap.end()) {
-      logger.log(0, "missing value in provided trace @{}: {}, {}" ,
+      logger.log(0, "missing value in provided trace @{}: {}" ,
         t,
-        sig_array_ptr->full_name,
-        sig_array_ptr->ast->to_string());
+        sig_array_ptr->full_name);
       continue;
     }
     smt::Term memvalue = pos->second;

--- a/printers/vcd_witness_printer.cpp
+++ b/printers/vcd_witness_printer.cpp
@@ -493,7 +493,7 @@ void VCDWitnessPrinter::dump_diff(const smt::UnorderedTermMap & valmap,
         if (prev_pos == valprev.end()) {
           valprev.insert(std::make_pair(addr_pos->second, data_default ));
           fout << data_default << " " << addr_pos->second << std::endl;
-          logger.log(0, "{} was not cached before time : {}.",
+          logger.log(1, "{} was not cached before time : {}.",
             sig_array_ptr->full_name+"[default]", std::to_string(t));
         } else {
           if (prev_pos->second != data_default) {

--- a/printers/vcd_witness_printer.cpp
+++ b/printers/vcd_witness_printer.cpp
@@ -432,7 +432,7 @@ void VCDWitnessPrinter::dump_diff(const smt::UnorderedTermMap & valmap,
     if (prev_pos == valprev.end()) {
       valprev.insert(std::make_pair(sig_bv_ptr->hash, val ));
       fout << val << " " << sig_bv_ptr->hash << std::endl;
-      logger.log(0, "Bug, {} was not cached before time : {}.",
+      logger.log(1, "Bug, {} was not cached before time : {}.",
         sig_bv_ptr->full_name, std::to_string(t));
       continue;
     }

--- a/printers/vcd_witness_printer.cpp
+++ b/printers/vcd_witness_printer.cpp
@@ -248,18 +248,20 @@ void VCDWitnessPrinter::GenHeader(std::ostream & fout) const {
     fout << buffer << std::endl;
   }
   fout << "$end" << std::endl;
-  fout << "$timescale 1ns $end" << std::endl;
+  fout << "$version CoSA2 $end" << std::endl;
+  fout << "$timescale 1 ns $end" << std::endl;
   DumpScopes(fout);
   fout << "$enddefinitions $end" << std::endl;
 } // GenHeader
 
 void VCDWitnessPrinter::dump_all(const smt::UnorderedTermMap & valmap,
   std::unordered_map<std::string, std::string> & valbuf,
-  std::ostream & fout) const {
+  uint64_t t, std::ostream & fout) const {
   for (auto && hash_sig_pair : hash2sig_bv_) {
     auto pos = valmap.find(hash_sig_pair.second->ast);
     if (pos == valmap.end()) {
-      logger.log(0, "missing val in valmap: {} ,{}, {}" ,
+      logger.log(0, "missing value in provided trace @{}: {} ,{}, {}" ,
+        t,
         hash_sig_pair.second->full_name,
         hash_sig_pair.first, 
         hash_sig_pair.second->ast->to_string());
@@ -277,12 +279,16 @@ void VCDWitnessPrinter::dump_all(const smt::UnorderedTermMap & valmap,
 
 void VCDWitnessPrinter::dump_diff(const smt::UnorderedTermMap & valmap,
   std::unordered_map<std::string, std::string> & valprev,
-  std::ostream & fout) const {
+  uint64_t t, std::ostream & fout) const {
 
   for (auto && hash_sig_pair : hash2sig_bv_) {
     auto pos = valmap.find(hash_sig_pair.second->ast);
     if (pos == valmap.end()) {
-      // logger.log(0, "missing val in valmap {}" , hash_sig_pair.second->to_string());
+      logger.log(0, "missing value in provided trace @{}: {} ,{}, {}" ,
+        t,
+        hash_sig_pair.second->full_name,
+        hash_sig_pair.first, 
+        hash_sig_pair.second->ast->to_string());
       continue;
     }
     auto val = as_bits(pos->second->to_string());
@@ -310,10 +316,10 @@ void VCDWitnessPrinter::DumpValues(std::ostream & fout,
   std::unordered_map<std::string, std::string> hash_to_value_map;
   // used to store the previous value for comparison
   fout << "#0" << std::endl;
-  dump_all(cex.at(0), hash_to_value_map, fout);
+  dump_all(cex.at(0), hash_to_value_map, 0, fout);
   for (uint64_t t = 1; t < cex.size(); ++t ) {
     fout << "#" << t << std::endl;
-    dump_diff(cex.at(t), hash_to_value_map, fout);
+    dump_diff(cex.at(t), hash_to_value_map, t, fout);
   }
   fout << "#" << cex.size() << std::endl;
 }

--- a/printers/vcd_witness_printer.cpp
+++ b/printers/vcd_witness_printer.cpp
@@ -497,7 +497,7 @@ void VCDWitnessPrinter::dump_diff(const smt::UnorderedTermMap & valmap,
         if (prev_pos == valprev.end()) {
           valprev.insert(std::make_pair(addr_pos->second, data ));
           fout << data << " " << addr_pos->second << std::endl;
-          logger.log(0, "Bug, {} was not cached before time : {}.",
+          logger.log(0, "{} was not cached before time : {}.",
             sig_array_ptr->full_name+"["+addr+"]", std::to_string(t));
         } else {
           if (prev_pos->second != data) {
@@ -521,7 +521,7 @@ void VCDWitnessPrinter::dump_diff(const smt::UnorderedTermMap & valmap,
         if (prev_pos == valprev.end()) {
           valprev.insert(std::make_pair(addr_pos->second, data_default ));
           fout << data_default << " " << addr_pos->second << std::endl;
-          logger.log(0, "Bug, {} was not cached before time : {}.",
+          logger.log(0, "{} was not cached before time : {}.",
             sig_array_ptr->full_name+"[default]", std::to_string(t));
         } else {
           if (prev_pos->second != data_default) {

--- a/printers/vcd_witness_printer.cpp
+++ b/printers/vcd_witness_printer.cpp
@@ -355,7 +355,7 @@ void VCDWitnessPrinter::dump_all(const smt::UnorderedTermMap & valmap,
   for (auto && sig_bv_ptr : allsig_bv_) {
     auto pos = valmap.find(sig_bv_ptr->ast);
     if (pos == valmap.end()) {
-      logger.log(0, "missing value in provided trace @{}: {}" ,
+      logger.log(1, "missing value in provided trace @{}: {}" ,
         t,
         sig_bv_ptr->full_name);
       continue;

--- a/printers/vcd_witness_printer.cpp
+++ b/printers/vcd_witness_printer.cpp
@@ -422,7 +422,7 @@ void VCDWitnessPrinter::dump_diff(const smt::UnorderedTermMap & valmap,
   for (auto && sig_bv_ptr : allsig_bv_) {
     auto pos = valmap.find(sig_bv_ptr->ast);
     if (pos == valmap.end()) {
-      logger.log(0, "missing value in provided trace @{}: {}" ,
+      logger.log(1, "missing value in provided trace @{}: {}" ,
         t,
         sig_bv_ptr->full_name);
       continue;

--- a/printers/vcd_witness_printer.cpp
+++ b/printers/vcd_witness_printer.cpp
@@ -19,43 +19,156 @@
 #include "smt-switch/boolector_factory.h"
 
 #include "vcd_witness_printer.h"
+// #include "btor2_witness_printer.h"
 
 #include <iostream>
+#include <fstream>
 
 using namespace smt;
 using namespace std;
 
 namespace cosa {
 
-const std::string_view vcd_header (R"**(
-$date %date% $end
-$version COSA2 $end
-$timescale 1 ns $end
-)**");
+static const char date_time_format [] = "%A %Y/%m/%d  %H:%M:%S";
+// const std::string_view vcd_header (R"**(
+// $date
+// %date%
+// $end
+// $version COSA2 $end
+// $timescale 1 ns $end
+// )**");
+
+// ------------- HELPER FUNCTIONS ------------------ //
+
+static std::vector<std::string> split(const std::string& str,
+                               const std::string& delim) {
+  std::vector<std::string> tokens;
+  size_t prev = 0, pos = 0;
+  do {
+    pos = str.find(delim, prev);
+    if (pos == std::string::npos)
+      pos = str.length();
+    std::string token = str.substr(prev, pos - prev);
+    if (!token.empty())
+      tokens.push_back(token);
+    prev = pos + delim.length();
+  } while (pos < str.length() && prev < str.length());
+  return tokens;
+}
+
+
+/// convert a widith to a verilog string
+static std::string width2range(uint64_t w) {
+  if (w > 1)
+    return std::string("[") + std::to_string(w - 1) + ":0]";
+  return "";
+}
+
+/// copied from btor2_witness_printer,
+/// so that we don't need to include
+/// because its header contains also 
+/// implementation, this creates troubles
+static std::string as_bits(std::string val)
+{
+  // TODO: this makes assumptions on format of value from boolector
+  //       to support other solvers, we need to be more general
+  std::string res = val;
+
+  if (val.length() < 2) {
+    throw CosaException("Don't know how to interpret value: " + val);
+  }
+
+  if (res.substr(0, 2) == "#b") {
+    // #b prefix -> b
+    res = res.substr(1, val.length() - 1);
+  } else if (res.substr(0, 2) == "#x") {
+    throw CosaException("Not supporting hexadecimal format yet.");
+  } else {
+    res = res.substr(5, res.length() - 5);
+    std::istringstream iss(res);
+    std::vector<std::string> tokens(std::istream_iterator<std::string>{ iss },
+                                    std::istream_iterator<std::string>());
+
+    if (tokens.size() != 2) {
+      throw CosaException("Failed to interpret " + val);
+    }
+
+    res = tokens[0];
+    // get rid of ")"
+    std::string width_str = tokens[1].substr(0, tokens[1].length() - 1);
+    size_t width = std::stoull(width_str);
+    mpz_class cval(res);
+    res = cval.get_str(2);
+    size_t strlen = res.length();
+
+    if (strlen < width) {
+      // pad with zeros
+      res = std::string(width - strlen, '0') + res;
+    } else if (strlen > width) {
+      // remove prepended zeros
+      res = res.erase(0, strlen - width);
+    }
+    return res;
+  }
+  return res;
+}
+
+
+// ------------- CLASS FUNCTIONS ------------------ //
+
 
 VCDWitnessPrinter::VCDWitnessPrinter(const BTOR2Encoder & btor_enc,
-                    const std::vector<smt::UnorderedTermMap> & cex) :
-  inputs(btor_enc.inputsvec()),
-  states(btor_enc.statesvec()),
-  no_next_states(btor_enc.no_next_states()),
-  has_states_without_next(!no_next_states.empty())
+                    const TransitionSystem & ts) :
+  inputs_(btor_enc.inputsvec()),
+  states_(btor_enc.statesvec()),
+  no_next_states_(btor_enc.no_next_states()),
+  has_states_without_next_(!no_next_states_.empty()),
+  named_terms_(ts.named_terms()),
+  hash_id_cnt_(0)
 {
   // figure out the variables and their scopes
+  for (auto && name_term_pair : named_terms_) {
+    bool is_reg = 
+      std::find(states_.begin(), states_.end(), name_term_pair.second)
+      != states_.end();
+    auto sk = name_term_pair.second->get_sort()->get_sort_kind();
+    if (sk == smt::ARRAY) {
+      continue; // let's not worry about array so far
+    }
+    check_insert_scope(name_term_pair.first, is_reg, name_term_pair.second);
+  }
+
+  for (auto && state : states_) {
+    if(state->get_sort()->get_sort_kind() == smt::ARRAY)
+      continue;
+    check_insert_scope(state->to_string(), true, state);
+  }
+
+
+  for (auto && input : inputs_) {
+    if(input->get_sort()->get_sort_kind() == smt::ARRAY)
+      continue;
+    check_insert_scope(input->to_string(), false, input);
+  }
+
 
   // you also need to figure out the indices used for each array
   // and dump these values when needed and dump the default value
   logger.log(0, "-------------Input Dump-----------------");
-  for (auto && i: inputs) {
+  for (auto && i: inputs_) {
     logger.log(0, "{}", i->to_string());
   }
   logger.log(0, "-------------State Dump-----------------");
-  for (auto && s: states) {
+  for (auto && s: states_) {
     logger.log(0, "{}", s->to_string());
   }
   logger.log(0, "-------------No Next States-----------------");
-  for (auto && s: no_next_states) {
+  for (auto && s: no_next_states_) {
     logger.log(0, "{}", s.second->to_string());
   }
+}
+
+void VCDWitnessPrinter::DebugDump(const std::vector<smt::UnorderedTermMap> & cex) const {
   for (uint64_t fidx = 0; fidx < cex.size(); ++ fidx) {
     logger.log(0, "------------- CEX : F{} -----------------", fidx);
     for (auto && t : cex.at(fidx)) {
@@ -64,6 +177,156 @@ VCDWitnessPrinter::VCDWitnessPrinter(const BTOR2Encoder & btor_enc,
   }
 }
 
+std::string VCDWitnessPrinter::new_hash_id() {
+  return "v" + std::to_string(hash_id_cnt_++);
+}
 
+void VCDWitnessPrinter::check_insert_scope(const std::string& full_name, bool is_reg,
+  const smt::Term & ast)
+{
+  auto scopes = split(full_name, ".");
+  VCDScope * root = & root_scope_;
+  for (size_t idx = 0; idx < scopes.size() - 1; ++idx) {
+    const auto & next_scope = scopes.at(idx);
+    auto pos = root->subscopes.find(next_scope);
+    if (pos != root->subscopes.end()) { // we find it
+      root = & (pos->second);
+    } else { // we need to insert this scope
+      root->subscopes.insert(std::make_pair(next_scope, VCDScope()));
+      root = &( root->subscopes.at(next_scope) );
+    }
+  } // at the end of this loop, we are at the scope to insert our variable
+  const auto & short_name = scopes.back();
+  uint64_t width = ast->get_sort()->get_width();
+
+  std::map<std::string, VCDSignal> & signal_set = is_reg ? root->regs : root->wires;
+
+  if (signal_set.find(short_name) != signal_set.end()) {
+    // TODO: only check in Debug
+    throw CosaException(full_name + " has been registered already");
+  }
+  auto hashid = new_hash_id();
+  signal_set.insert(std::make_pair(short_name,
+    VCDSignal(
+      short_name + width2range(width), 
+      full_name,  hashid , ast, width)));
+  hash2sig_bv_.insert(std::make_pair(hashid, &(signal_set.at(short_name)) ));
+}
+
+
+void VCDWitnessPrinter::dump_current_scope(std::ostream & fout, const VCDScope *scope) const {
+  for (auto && r : scope->regs) {
+    fout << "$var reg " << r.second.data_width << " " << r.second.hash << " "
+         << r.second.vcd_name << " $end" << std::endl;
+  }
+  for (auto && w : scope->wires) {
+    fout << "$var wire " << w.second.data_width << " " << w.second.hash << " "
+         << w.second.vcd_name << " $end" << std::endl;
+  }
+  // let's go for the submodules
+  for (auto pos = scope->subscopes.begin() ; pos != scope->subscopes.end() ; ++ pos) {
+    fout << "$scope module " << pos->first << " $end" << std::endl;
+    dump_current_scope(fout, &(pos->second));
+    fout << "$upscope $end" << std::endl;
+  }
+} // end of dump_current_scope
+
+void VCDWitnessPrinter::DumpScopes(std::ostream & fout) const {
+  dump_current_scope(fout, &root_scope_);
+}
+
+void VCDWitnessPrinter::GenHeader(std::ostream & fout) const {
+  fout << "$date" << std::endl;
+  {
+    char buffer [100];
+    time_t rawtime;
+    struct tm * timeinfo;
+    time (&rawtime);
+    timeinfo = localtime (&rawtime);
+    if ( strftime(buffer, 100, date_time_format, timeinfo) == 0)
+      throw CosaException("Bug: time2string conversion failed.");
+    fout << buffer << std::endl;
+  }
+  fout << "$end" << std::endl;
+  fout << "$timescale 1ns $end" << std::endl;
+  DumpScopes(fout);
+  fout << "$enddefinitions $end" << std::endl;
+} // GenHeader
+
+void VCDWitnessPrinter::dump_all(const smt::UnorderedTermMap & valmap,
+  std::unordered_map<std::string, std::string> & valbuf,
+  std::ostream & fout) const {
+  for (auto && hash_sig_pair : hash2sig_bv_) {
+    auto pos = valmap.find(hash_sig_pair.second->ast);
+    if (pos == valmap.end()) {
+      logger.log(0, "missing val in valmap: {} ,{}, {}" ,
+        hash_sig_pair.second->full_name,
+        hash_sig_pair.first, 
+        hash_sig_pair.second->ast->to_string());
+      continue;
+    }
+    auto val = as_bits(pos->second->to_string());
+    valbuf.insert(std::make_pair(
+      hash_sig_pair.first,
+      val
+    ));
+    fout << val << " " << hash_sig_pair.first << std::endl;
+  }
+  // TODO : mems
+}
+
+void VCDWitnessPrinter::dump_diff(const smt::UnorderedTermMap & valmap,
+  std::unordered_map<std::string, std::string> & valprev,
+  std::ostream & fout) const {
+
+  for (auto && hash_sig_pair : hash2sig_bv_) {
+    auto pos = valmap.find(hash_sig_pair.second->ast);
+    if (pos == valmap.end()) {
+      // logger.log(0, "missing val in valmap {}" , hash_sig_pair.second->to_string());
+      continue;
+    }
+    auto val = as_bits(pos->second->to_string());
+    auto prev_pos = valprev.find(hash_sig_pair.first);
+    if (prev_pos == valprev.end())
+      throw CosaException("Bug, "+ hash_sig_pair.first + " is not cached.");
+    if ( prev_pos->second == val )
+      continue;
+    // update old value and print
+    prev_pos->second = val;
+    fout << val << " " << hash_sig_pair.first << std::endl;
+  }
+}
+
+void VCDWitnessPrinter::DumpValues(std::ostream & fout, 
+  const std::vector<smt::UnorderedTermMap> & cex) const {
+  // at time 0 we dump all the values
+  // and then at each later time, we compare and
+  // see if there is any difference, if not
+  // we just skip it
+  // finally add an empty time-tick
+  if (cex.empty())
+    throw CosaException("No trace to dump");
+
+  std::unordered_map<std::string, std::string> hash_to_value_map;
+  // used to store the previous value for comparison
+  fout << "#0" << std::endl;
+  dump_all(cex.at(0), hash_to_value_map, fout);
+  for (uint64_t t = 1; t < cex.size(); ++t ) {
+    fout << "#" << t << std::endl;
+    dump_diff(cex.at(t), hash_to_value_map, fout);
+  }
+  fout << "#" << cex.size() << std::endl;
+}
+
+
+void VCDWitnessPrinter::DumpTraceToFile(const std::string & vcd_file_name, 
+  const std::vector<smt::UnorderedTermMap> & cex) const {
+  
+  std::ofstream fout(vcd_file_name);
+  if (!fout.is_open())
+    throw CosaException("Unable to write to : " + vcd_file_name);
+  GenHeader(fout);
+  DumpValues(fout, cex);
+}
 
 } // namespace cosa

--- a/printers/vcd_witness_printer.cpp
+++ b/printers/vcd_witness_printer.cpp
@@ -469,7 +469,7 @@ void VCDWitnessPrinter::dump_diff(const smt::UnorderedTermMap & valmap,
         if (prev_pos == valprev.end()) {
           valprev.insert(std::make_pair(addr_pos->second, data ));
           fout << data << " " << addr_pos->second << std::endl;
-          logger.log(0, "{} was not cached before time : {}.",
+          logger.log(1, "{} was not cached before time : {}.",
             sig_array_ptr->full_name+"["+addr+"]", std::to_string(t));
         } else {
           if (prev_pos->second != data) {

--- a/printers/vcd_witness_printer.cpp
+++ b/printers/vcd_witness_printer.cpp
@@ -447,7 +447,7 @@ void VCDWitnessPrinter::dump_diff(const smt::UnorderedTermMap & valmap,
   for (auto && sig_array_ptr : allsig_array_) {
     auto pos = valmap.find(sig_array_ptr->ast);
     if (pos == valmap.end()) {
-      logger.log(0, "missing value in provided trace @{}: {}" ,
+      logger.log(1, "missing value in provided trace @{}: {}" ,
         t,
         sig_array_ptr->full_name);
       continue;

--- a/printers/vcd_witness_printer.cpp
+++ b/printers/vcd_witness_printer.cpp
@@ -252,8 +252,8 @@ void VCDWitnessPrinter::check_insert_scope(const std::string& full_name, bool is
   std::map<std::string, VCDSignal> & signal_set = is_reg ? root->regs : root->wires;
 
   if (signal_set.find(short_name) != signal_set.end()) {
-    // TODO: only check in Debug
-    throw CosaException(full_name + " has been registered already");
+    logger.log(1, full_name + " has been registered already");
+    return;
   }
   auto hashid = new_hash_id();
   signal_set.insert(std::make_pair(short_name,

--- a/printers/vcd_witness_printer.cpp
+++ b/printers/vcd_witness_printer.cpp
@@ -371,7 +371,7 @@ void VCDWitnessPrinter::dump_all(const smt::UnorderedTermMap & valmap,
   for (auto && sig_array_ptr : allsig_array_) {
     auto pos = valmap.find(sig_array_ptr->ast);
     if (pos == valmap.end()) {
-      logger.log(0, "missing value in provided trace @{}: {}" ,
+      logger.log(1, "missing value in provided trace @{}: {}" ,
         t,
         sig_array_ptr->full_name);
       continue;

--- a/printers/vcd_witness_printer.cpp
+++ b/printers/vcd_witness_printer.cpp
@@ -392,7 +392,7 @@ void VCDWitnessPrinter::dump_all(const smt::UnorderedTermMap & valmap,
         valbuf.insert(std::make_pair(addr_pos->second, data));
         fout << data << " " << addr_pos->second << std::endl;
       } else {
-        logger.log(0, "missing addr index for array: {}: , addr : {}" ,
+        logger.log(1, "missing addr index for array: {}: , addr : {}" ,
           sig_array_ptr->full_name, addr);
       }
 

--- a/printers/vcd_witness_printer.cpp
+++ b/printers/vcd_witness_printer.cpp
@@ -478,7 +478,7 @@ void VCDWitnessPrinter::dump_diff(const smt::UnorderedTermMap & valmap,
           }
         } // exists in prev pos or not
       } else {
-        logger.log(0, "missing addr index for array: {}: , addr : {}" ,
+        logger.log(1, "missing addr index for array: {}: , addr : {}" ,
           sig_array_ptr->full_name, addr);
       }
       memvalue = store_children[0];

--- a/printers/vcd_witness_printer.cpp
+++ b/printers/vcd_witness_printer.cpp
@@ -502,7 +502,7 @@ void VCDWitnessPrinter::dump_diff(const smt::UnorderedTermMap & valmap,
           }
         } // exists in prev pos or not
       } else {
-        logger.log(0, "missing addr index for array: {}: , addr : {}" ,
+        logger.log(1, "missing addr index for array: {}: , addr : {}" ,
           sig_array_ptr->full_name, "-default-");
       }
     } // handling the inner constant default

--- a/printers/vcd_witness_printer.cpp
+++ b/printers/vcd_witness_printer.cpp
@@ -1,0 +1,69 @@
+/*********************                                                        */
+/*! \file 
+ ** \verbatim
+ ** Top contributors (to current version):
+ **   Hongce Zhang
+ ** This file is part of the cosa2 project.
+ ** Copyright (c) 2019 by the authors listed in the file AUTHORS
+ ** in the top-level source directory) and their institutional affiliations.
+ ** All rights reserved.  See the file LICENSE in the top-level source
+ ** directory for licensing information.\endverbatim
+ **
+ ** \brief 
+ **
+ ** 
+ **/
+
+#include "utils/logger.h"
+#include "frontends/btor2_encoder.h"
+#include "smt-switch/boolector_factory.h"
+
+#include "vcd_witness_printer.h"
+
+#include <iostream>
+
+using namespace smt;
+using namespace std;
+
+namespace cosa {
+
+const std::string_view vcd_header (R"**(
+$date %date% $end
+$version COSA2 $end
+$timescale 1 ns $end
+)**");
+
+VCDWitnessPrinter::VCDWitnessPrinter(const BTOR2Encoder & btor_enc,
+                    const std::vector<smt::UnorderedTermMap> & cex) :
+  inputs(btor_enc.inputsvec()),
+  states(btor_enc.statesvec()),
+  no_next_states(btor_enc.no_next_states()),
+  has_states_without_next(!no_next_states.empty())
+{
+  // figure out the variables and their scopes
+
+  // you also need to figure out the indices used for each array
+  // and dump these values when needed and dump the default value
+  logger.log(0, "-------------Input Dump-----------------");
+  for (auto && i: inputs) {
+    logger.log(0, "{}", i->to_string());
+  }
+  logger.log(0, "-------------State Dump-----------------");
+  for (auto && s: states) {
+    logger.log(0, "{}", s->to_string());
+  }
+  logger.log(0, "-------------No Next States-----------------");
+  for (auto && s: no_next_states) {
+    logger.log(0, "{}", s.second->to_string());
+  }
+  for (uint64_t fidx = 0; fidx < cex.size(); ++ fidx) {
+    logger.log(0, "------------- CEX : F{} -----------------", fidx);
+    for (auto && t : cex.at(fidx)) {
+      logger.log(0, "{} -> {}", t.first->to_string(), t.second->to_string() );
+    }
+  }
+}
+
+
+
+} // namespace cosa

--- a/printers/vcd_witness_printer.cpp
+++ b/printers/vcd_witness_printer.cpp
@@ -407,7 +407,7 @@ void VCDWitnessPrinter::dump_all(const smt::UnorderedTermMap & valmap,
         valbuf.insert(std::make_pair(addr_pos->second, data_default));
         fout << data_default << " " << addr_pos->second << std::endl;
       } else {
-        logger.log(0, "missing addr index for array: {}: , addr : {}" ,
+        logger.log(1, "missing addr index for array: {}: , addr : {}" ,
           sig_array_ptr->full_name, "-default-");
       }
     } // handling the inner constant default

--- a/printers/vcd_witness_printer.h
+++ b/printers/vcd_witness_printer.h
@@ -45,7 +45,12 @@ struct VCDSignal {
 }; 
 
 struct VCDArray : public VCDSignal {
-  std::set<std::string> indices;
+  std::unordered_map<std::string, std::string> indices2hash;
+  VCDArray (
+    const std::string & _vcd_name, 
+    const std::string & _full_name,
+    const smt::Term & _ast, uint64_t w) :
+    VCDSignal(_vcd_name, _full_name, "", _ast, w) {}
 };
 
 struct VCDScope {
@@ -65,17 +70,21 @@ protected:
   const std::map<uint64_t, smt::Term> no_next_states_;
   const bool has_states_without_next_;
   const std::unordered_map<std::string, smt::Term> & named_terms_;
+  const std::vector<smt::UnorderedTermMap> & cex_;
   
   VCDScope root_scope_;
   // hash id --> signal object
-  std::unordered_map<std::string, VCDSignal *> hash2sig_bv_;
+  std::vector<VCDSignal *> allsig_bv_;
+  std::vector<VCDArray  *> allsig_array_;
 
   // given a name like a.b.c, find the right scope and
   // create if it does not exists
   void check_insert_scope(const std::string& full_name, 
     bool is_reg, const smt::Term & ast);
   // another function for array maybe?
-  // check_insert_scope
+  void check_insert_scope_array(const std::string& full_name, 
+    const std::unordered_set<std::string> & indices, bool has_default,
+    const smt::Term & ast);
 
   uint64_t hash_id_cnt_;
   std::string new_hash_id();
@@ -89,20 +98,23 @@ protected:
     std::unordered_map<std::string, std::string> & valprev,
     uint64_t tick, std::ostream & fout) const;
 
-public:
-  // in case you want to use separately
+
+protected:
+
   void DumpScopes(std::ostream & fout) const;
   void GenHeader(std::ostream & fout) const;
-  void DumpValues(std::ostream & fout, 
-    const std::vector<smt::UnorderedTermMap> & cex) const;
+  void DumpValues(std::ostream & fout) const;
 
-  void DumpTraceToFile(const std::string & vcd_file_name, 
-    const std::vector<smt::UnorderedTermMap> & cex) const;
+
   
+public:
   VCDWitnessPrinter(const BTOR2Encoder & btor_enc,
-                    const TransitionSystem & ts);
+                    const TransitionSystem & ts,
+                    const std::vector<smt::UnorderedTermMap> & cex);
 
-  void DebugDump(const std::vector<smt::UnorderedTermMap> & cex) const;
+
+  void DumpTraceToFile(const std::string & vcd_file_name) const;
+  void DebugDump() const;
 
 }; // class VCDWitnessPrinter
 

--- a/printers/vcd_witness_printer.h
+++ b/printers/vcd_witness_printer.h
@@ -84,10 +84,10 @@ protected:
 
   void dump_all(const smt::UnorderedTermMap & valmap,
     std::unordered_map<std::string, std::string> & valbuf,
-    std::ostream & fout) const;
+    uint64_t tick, std::ostream & fout) const;
   void dump_diff(const smt::UnorderedTermMap & valmap,
     std::unordered_map<std::string, std::string> & valprev,
-    std::ostream & fout) const;
+    uint64_t tick, std::ostream & fout) const;
 
 public:
   // in case you want to use separately

--- a/printers/vcd_witness_printer.h
+++ b/printers/vcd_witness_printer.h
@@ -19,18 +19,40 @@
 #include <map>
 #include <sstream>
 #include <vector>
+#include <set>
 
 #include "gmpxx.h"
-
 #include "smt-switch/smt.h"
 
 #include "utils/logger.h"
 
 namespace cosa {
 
+struct VCDSignal {
+  std::string vcd_name; // maybe you want to add this : [N:0]
+  std::string full_name;
+  std::string hash;
+  smt::Term   ast;
+  uint64_t    data_width;
+  VCDSignal (
+    const std::string & _vcd_name, 
+    const std::string & _full_name,
+    const std::string & _hash,
+    const smt::Term & _ast, uint64_t w) : 
+      vcd_name(_vcd_name), 
+      full_name(_full_name),
+      hash(_hash), ast(_ast), data_width(w) {}
+}; 
+
+struct VCDArray : public VCDSignal {
+  std::set<std::string> indices;
+};
+
 struct VCDScope {
-  std::vector<VCDScope> subscopes;
-  smt::TermVec variables;
+  std::map<std::string, VCDScope> subscopes;
+  std::map<std::string, VCDSignal>  wires;
+  std::map<std::string, VCDSignal>  regs;
+  std::map<std::string, VCDArray> arrays;
 }; // struct VCDScope
 
 class VCDWitnessPrinter {
@@ -38,20 +60,49 @@ public:
   // types
   typedef std::map<std::string, std::vector<std::string>> per_mem_indices;
 protected:
-  const smt::TermVec inputs;
-  const smt::TermVec states;
-  const std::map<uint64_t, smt::Term> no_next_states;
-  const bool has_states_without_next;
+  const smt::TermVec inputs_;
+  const smt::TermVec states_;
+  const std::map<uint64_t, smt::Term> no_next_states_;
+  const bool has_states_without_next_;
+  const std::unordered_map<std::string, smt::Term> & named_terms_;
   
-  VCDScope root_scope;
+  VCDScope root_scope_;
+  // hash id --> signal object
+  std::unordered_map<std::string, VCDSignal *> hash2sig_bv_;
 
   // given a name like a.b.c, find the right scope and
   // create if it does not exists
-  void check_insert_scope(const std::string& full_name);
+  void check_insert_scope(const std::string& full_name, 
+    bool is_reg, const smt::Term & ast);
+  // another function for array maybe?
+  // check_insert_scope
+
+  uint64_t hash_id_cnt_;
+  std::string new_hash_id();
+
+  void dump_current_scope(std::ostream & fout, const VCDScope *) const;
+
+  void dump_all(const smt::UnorderedTermMap & valmap,
+    std::unordered_map<std::string, std::string> & valbuf,
+    std::ostream & fout) const;
+  void dump_diff(const smt::UnorderedTermMap & valmap,
+    std::unordered_map<std::string, std::string> & valprev,
+    std::ostream & fout) const;
 
 public:
+  // in case you want to use separately
+  void DumpScopes(std::ostream & fout) const;
+  void GenHeader(std::ostream & fout) const;
+  void DumpValues(std::ostream & fout, 
+    const std::vector<smt::UnorderedTermMap> & cex) const;
+
+  void DumpTraceToFile(const std::string & vcd_file_name, 
+    const std::vector<smt::UnorderedTermMap> & cex) const;
+  
   VCDWitnessPrinter(const BTOR2Encoder & btor_enc,
-                    const std::vector<smt::UnorderedTermMap> & cex);
+                    const TransitionSystem & ts);
+
+  void DebugDump(const std::vector<smt::UnorderedTermMap> & cex) const;
 
 }; // class VCDWitnessPrinter
 

--- a/printers/vcd_witness_printer.h
+++ b/printers/vcd_witness_printer.h
@@ -1,0 +1,58 @@
+/*********************                                                        */
+/*! \file 
+ ** \verbatim
+ ** Top contributors (to current version):
+ **   Hongce Zhang
+ ** This file is part of the cosa2 project.
+ ** Copyright (c) 2019 by the authors listed in the file AUTHORS
+ ** in the top-level source directory) and their institutional affiliations.
+ ** All rights reserved.  See the file LICENSE in the top-level source
+ ** directory for licensing information.\endverbatim
+ **
+ ** \brief 
+ **
+ ** 
+ **/
+
+
+#include <iterator>
+#include <map>
+#include <sstream>
+#include <vector>
+
+#include "gmpxx.h"
+
+#include "smt-switch/smt.h"
+
+#include "utils/logger.h"
+
+namespace cosa {
+
+struct VCDScope {
+  std::vector<VCDScope> subscopes;
+  smt::TermVec variables;
+}; // struct VCDScope
+
+class VCDWitnessPrinter {
+public:
+  // types
+  typedef std::map<std::string, std::vector<std::string>> per_mem_indices;
+protected:
+  const smt::TermVec inputs;
+  const smt::TermVec states;
+  const std::map<uint64_t, smt::Term> no_next_states;
+  const bool has_states_without_next;
+  
+  VCDScope root_scope;
+
+  // given a name like a.b.c, find the right scope and
+  // create if it does not exists
+  void check_insert_scope(const std::string& full_name);
+
+public:
+  VCDWitnessPrinter(const BTOR2Encoder & btor_enc,
+                    const std::vector<smt::UnorderedTermMap> & cex);
+
+}; // class VCDWitnessPrinter
+
+}  // namespace cosa


### PR DESCRIPTION
Hi Makai,

Here is my implementation of VCD generator (invoked with `--vcd <vcdname>`).

There are two things that are relevant but not included.

* Dumping the value of wires. I think `prover->witness` does not generate the value of wires (named terms). I have changed that on my other branch 9a80fb45e10fce16b72403629ee31735f74f4a85, but I don't know whether you want this change or not, so I didn't include it

* Adapt for a quirk of yosys. If you have something like `output reg a` in Verilog, yosys will create a state without name and an output name `a`. In my other branch, I will rename that state with `a` and also register it as an output with the same name in `named_terms`.

Please feel free to take whatever part of the code that is useful for you, and please let me know when there is any bug found in the VCD generator.

Thank you!
