### PR TITLE
Switch back to badvec in btor-encoder

### DIFF
--- a/cosa2.cpp
+++ b/cosa2.cpp
@@ -258,16 +258,16 @@ int main(int argc, char ** argv)
       logger.log(2, "Parsing BTOR2 file: {}", filename);
       FunctionalTransitionSystem fts(s);
       BTOR2Encoder btor_enc(filename, fts);
-      const TermVec & propvec = btor_enc.propvec();
-      unsigned int num_props = propvec.size();
+      const TermVec & badvec = btor_enc.badvec();
+      unsigned int num_props = badvec.size();
       if (prop_idx >= num_props) {
         throw CosaException(
             "Property index " + to_string(prop_idx)
             + " is greater than the number of properties in file " + filename
             + " (" + to_string(num_props) + ")");
       }
-      Term prop = propvec[prop_idx];
-      Property p(fts, prop);
+      Term bad = badvec[prop_idx];
+      Property p(fts, s->make_term(Not, bad));
       vector<UnorderedTermMap> cex;
       r = check_prop(engine, bound, p, s, second_solver, cex);
 

--- a/cosa2.cpp
+++ b/cosa2.cpp
@@ -258,16 +258,16 @@ int main(int argc, char ** argv)
       logger.log(2, "Parsing BTOR2 file: {}", filename);
       FunctionalTransitionSystem fts(s);
       BTOR2Encoder btor_enc(filename, fts);
-      const TermVec & badvec = btor_enc.badvec();
-      unsigned int num_props = badvec.size();
+      const TermVec & propvec = btor_enc.propvec();
+      unsigned int num_props = propvec.size();
       if (prop_idx >= num_props) {
         throw CosaException(
             "Property index " + to_string(prop_idx)
             + " is greater than the number of properties in file " + filename
             + " (" + to_string(num_props) + ")");
       }
-      Term bad = badvec[prop_idx];
-      Property p(fts, s->make_term(Not, bad));
+      Term propterm = propvec[prop_idx];
+      Property p(fts, propterm);
       vector<UnorderedTermMap> cex;
       r = check_prop(engine, bound, p, s, second_solver, cex);
 

--- a/frontends/btor2_encoder.cpp
+++ b/frontends/btor2_encoder.cpp
@@ -401,14 +401,13 @@ void BTOR2Encoder::parse(const std::string filename)
         Term witness =
             ts_.make_state("witness_" + std::to_string(witness_id_++),
                            solver_->make_sort(BOOL));
-        ts_.constrain_init(witness);
-        ts_.assign_next(witness, solver_->make_term(Not, bad));
-        propvec_.push_back(witness);
+        ts_.constrain_init(solver_->make_term(Not, witness));
+        ts_.assign_next(witness, bad);
+        badvec_.push_back(witness);
         terms_[l_->id] = witness;
       } else {
-        Term prop = solver_->make_term(Not, bad);
-        propvec_.push_back(prop);
-        terms_[l_->id] = prop;
+        badvec_.push_back(bad);
+        terms_[l_->id] = bad;
       }
     } else if (l_->tag == BTOR2_TAG_justice) {
       std::cout << "Warning: ignoring justice term" << std::endl;

--- a/frontends/btor2_encoder.cpp
+++ b/frontends/btor2_encoder.cpp
@@ -403,10 +403,10 @@ void BTOR2Encoder::parse(const std::string filename)
                            solver_->make_sort(BOOL));
         ts_.constrain_init(solver_->make_term(Not, witness));
         ts_.assign_next(witness, bad);
-        badvec_.push_back(witness);
+        propvec_.push_back(solver_->make_term(Not, witness));
         terms_[l_->id] = witness;
       } else {
-        badvec_.push_back(bad);
+        propvec_.push_back(solver_->make_term(Not, bad));
         terms_[l_->id] = bad;
       }
     } else if (l_->tag == BTOR2_TAG_justice) {

--- a/frontends/btor2_encoder.h
+++ b/frontends/btor2_encoder.h
@@ -44,7 +44,7 @@ class BTOR2Encoder
     parse(filename);
   };
 
-  const smt::TermVec & badvec() const { return badvec_; };
+  const smt::TermVec & propvec() const { return propvec_; };
   const smt::TermVec & justicevec() const { return justicevec_; };
   const smt::TermVec & fairvec() const { return fairvec_; };
   const smt::TermVec & inputsvec() const { return inputsvec_; }
@@ -87,7 +87,7 @@ class BTOR2Encoder
   std::unordered_map<int, smt::Term> terms_;
   std::string symbol_;
 
-  smt::TermVec badvec_;
+  smt::TermVec propvec_;
   smt::TermVec justicevec_;
   smt::TermVec fairvec_;
 

--- a/frontends/btor2_encoder.h
+++ b/frontends/btor2_encoder.h
@@ -44,7 +44,7 @@ class BTOR2Encoder
     parse(filename);
   };
 
-  const smt::TermVec & propvec() const { return propvec_; };
+  const smt::TermVec & badvec() const { return badvec_; };
   const smt::TermVec & justicevec() const { return justicevec_; };
   const smt::TermVec & fairvec() const { return fairvec_; };
   const smt::TermVec & inputsvec() const { return inputsvec_; }
@@ -87,7 +87,7 @@ class BTOR2Encoder
   std::unordered_map<int, smt::Term> terms_;
   std::string symbol_;
 
-  smt::TermVec propvec_;
+  smt::TermVec badvec_;
   smt::TermVec justicevec_;
   smt::TermVec fairvec_;
 


### PR DESCRIPTION
I recently noticed that we get an incorrect result (actually the result is the same but the bound is wrong). The bug in the attached btor2 file should be triggered around bound 36 or something, but instead it's triggered at bound 7. Perhaps even worse, it was nondeterministic -- sometimes it would fail at bound 7, and changing something unrelated like the verbosity would make it get to bound 10 without a problem.

By going through the cosa2 history I found that changes to the btor2 encoder caused this. On my machine, this works. However, I have no idea why it's any different. It should be functionally equivalent. I'm curious what the performance is on another machine.

[btor-nondet.tar.gz](https://github.com/upscale-project/cosa2/files/4513177/btor-nondet.tar.gz)
