### PR TITLE
Updates to keep in line with smt-switch

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -39,7 +39,8 @@ script:
   - ./scripts/travis-setup-osx-python.sh || true
   - sudo python3 -m pip install Cython==0.29 --install-option="--no-cython-compile"
   - sudo python3 -m pip install pytest
-  - ./contrib/setup-smt-switch.sh --with-msat --auto-yes --python
+  - ./travis-scripts/setup-msat.sh --auto-yes
+  - ./contrib/setup-smt-switch.sh --with-msat --python
   - sudo python3 -m pip install -e ./deps/smt-switch/build/python
   - ./contrib/setup-btor2tools.sh
   - ./contrib/setup-bison.sh

--- a/README.md
+++ b/README.md
@@ -4,8 +4,10 @@ Next generation cosa.
 ## Setup
 
 * Run `./contrib/setup-smt-switch.sh` -- it will build smt-switch with boolector
-  * add `--with-msat` to also build with MathSAT (required for interpolant-based model checking)
+* [optional] to build with MathSAT (required for interpolant-based model checking) you need to obtain the libraries yourself
   * note that MathSAT is under a custom non-BSD compliant license and you must assume all responsibility for meeting the conditions
+  * download the solver from https://mathsat.fbk.eu/download.html, unpack it and rename the directory to `./deps/mathsat`
+  * then add the `--with-msat` flag to the `setup-smt-switch.sh` command.
 * Run `./contrib/setup-btor2tools.sh`.
 * Run `./configure.sh`.
 * Run `cd build`.

--- a/contrib/setup-smt-switch.sh
+++ b/contrib/setup-smt-switch.sh
@@ -35,7 +35,7 @@ do
         -h|--help) usage;;
         --with-msat)
             WITH_MSAT=ON
-            CONF_OPTS="$CONF_OPTS --msat";;
+            CONF_OPTS="$CONF_OPTS --msat --msat-home=../mathsat";;
         --with-cvc4)
             WITH_CVC4=ON
             CONF_OPTS="$CONF_OPTS --cvc4";;
@@ -55,10 +55,6 @@ if [ ! -d "$DEPS/smt-switch" ]; then
     git checkout -f $SMT_SWITCH_VERSION
     cd smt-switch
     ./contrib/setup-btor.sh
-
-    if [[ "$WITH_MSAT" != default ]]; then
-        ./travis-scripts/setup-msat.sh $MSAT_OPTS
-    fi
 
     if [[ "$WITH_CVC4" != default ]]; then
         ./contrib/setup-cvc4.sh

--- a/contrib/setup-smt-switch.sh
+++ b/contrib/setup-smt-switch.sh
@@ -49,7 +49,6 @@ if [ ! -d "$DEPS/smt-switch" ]; then
     cd $DEPS
     git clone https://github.com/makaimann/smt-switch
     cd smt-switch
-    git checkout -f $SMT_SWITCH_VERSION
     ./contrib/setup-btor.sh
 
     if [[ "$WITH_CVC4" != default ]]; then

--- a/contrib/setup-smt-switch.sh
+++ b/contrib/setup-smt-switch.sh
@@ -12,7 +12,6 @@ Sets up the smt-switch API for interfacing with SMT solvers through a C++ API.
 -h, --help              display this message and exit
 --with-cvc4             include CVC4 (default: off)
 --with-msat             include MathSAT which is under a custom non-BSD compliant license (default: off)
--y, --auto-yes          automatically agree to conditions (default: off)
 --python                build python bindings (default: off)
 EOF
     exit 0
@@ -37,7 +36,6 @@ do
         --with-cvc4)
             WITH_CVC4=ON
             CONF_OPTS="$CONF_OPTS --cvc4";;
-        -y|--auto-yes) MSAT_OPTS=--auto-yes;;
         --python)
             CONF_OPTS="$CONF_OPTS --python";;
         *) die "unexpected argument: $1";;

--- a/contrib/setup-smt-switch.sh
+++ b/contrib/setup-smt-switch.sh
@@ -57,7 +57,7 @@ if [ ! -d "$DEPS/smt-switch" ]; then
     ./contrib/setup-btor.sh
 
     if [[ "$WITH_MSAT" != default ]]; then
-        ./contrib/setup-msat.sh $MSAT_OPTS
+        ./travis-scripts/setup-msat.sh $MSAT_OPTS
     fi
 
     if [[ "$WITH_CVC4" != default ]]; then

--- a/contrib/setup-smt-switch.sh
+++ b/contrib/setup-smt-switch.sh
@@ -3,8 +3,6 @@
 DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
 DEPS=$DIR/../deps
 
-SMT_SWITCH_VERSION=d1676f083bf291382ce38f16ef8fb6db50e346ff
-
 usage () {
     cat <<EOF
 Usage: $0 [<option> ...]
@@ -52,7 +50,6 @@ mkdir -p $DEPS
 if [ ! -d "$DEPS/smt-switch" ]; then
     cd $DEPS
     git clone https://github.com/makaimann/smt-switch
-    git checkout -f $SMT_SWITCH_VERSION
     cd smt-switch
     ./contrib/setup-btor.sh
 

--- a/cosa2.cpp
+++ b/cosa2.cpp
@@ -233,7 +233,7 @@ int main(int argc, char ** argv)
     if (engine == INTERP) {
       #ifdef WITH_MSAT
       // need mathsat for interpolant based model checking
-      s = MsatSolverFactory::create();
+      s = MsatSolverFactory::create(false);
       second_solver = MsatSolverFactory::create_interpolating_solver();
       #else
       throw CosaException("Interpolation-based model checking requires MathSAT and "
@@ -244,7 +244,7 @@ int main(int argc, char ** argv)
       #endif
     } else {
       // boolector is faster but doesn't support interpolants
-      s = BoolectorSolverFactory::create();
+      s = BoolectorSolverFactory::create(false);
       s->set_opt("produce-models", "true");
       s->set_opt("incremental", "true");
     }

--- a/tests/available_solvers.h
+++ b/tests/available_solvers.h
@@ -19,7 +19,7 @@
 
 namespace cosa_tests {
 
-typedef ::smt::SmtSolver (*create_solver_fun)(void);
+typedef ::smt::SmtSolver (*create_solver_fun)(bool);
 
 enum SolverEnum
 {

--- a/tests/python/test_engines.py
+++ b/tests/python/test_engines.py
@@ -53,7 +53,7 @@ def build_simple_alu_fts(s:ss.SmtSolver)->c.Property:
 
 @pytest.mark.parametrize("create_solver", ss.solvers.values())
 def test_bmc(create_solver):
-    s = create_solver()
+    s = create_solver(False)
     s.set_opt('produce-models', 'true')
     s.set_opt('incremental', 'true')
     prop = build_simple_alu_fts(s)
@@ -65,7 +65,7 @@ def test_bmc(create_solver):
 
 @pytest.mark.parametrize("create_solver", ss.solvers.values())
 def test_kind(create_solver):
-    s = create_solver()
+    s = create_solver(False)
     s.set_opt('produce-models', 'true')
     s.set_opt('incremental', 'true')
     prop = build_simple_alu_fts(s)
@@ -91,7 +91,7 @@ def test_interp(solver_and_interpolator):
 
 @pytest.mark.parametrize("create_solver", ss.solvers.values())
 def test_kind_inductive_prop(create_solver):
-    s = create_solver()
+    s = create_solver(False)
     s.set_opt('produce-models', 'true')
     s.set_opt('incremental', 'true')
     prop = build_simple_alu_fts(s)

--- a/tests/python/test_engines.py
+++ b/tests/python/test_engines.py
@@ -77,7 +77,7 @@ def test_kind(create_solver):
 
 @pytest.mark.parametrize("solver_and_interpolator", available_solvers.solver_and_interpolators.values())
 def test_interp(solver_and_interpolator):
-    s = solver_and_interpolator[0]()
+    s = solver_and_interpolator[0](False)
     s.set_opt('produce-models', 'true')
     s.set_opt('incremental', 'true')
     itp = solver_and_interpolator[1]()

--- a/tests/python/test_ts.py
+++ b/tests/python/test_ts.py
@@ -18,12 +18,12 @@ def build_simple_ts(solver, TS):
 
 @pytest.mark.parametrize("create_solver", ss.solvers.values())
 def test_cons_fts(create_solver):
-    solver = create_solver()
+    solver = create_solver(False)
     solver, ts = build_simple_ts(solver, c.FunctionalTransitionSystem)
 
 @pytest.mark.parametrize("create_solver", ss.solvers.values())
 def test_query_fts(create_solver):
-    solver = create_solver()
+    solver = create_solver(False)
     solver, ts = build_simple_ts(solver, c.FunctionalTransitionSystem)
 
     assert len(ts.states) == 2
@@ -40,7 +40,7 @@ def test_query_fts(create_solver):
 
 @pytest.mark.parametrize("create_solver", ss.solvers.values())
 def test_func_update_fts(create_solver):
-    solver = create_solver()
+    solver = create_solver(False)
     solver, ts = build_simple_ts(solver, c.FunctionalTransitionSystem)
 
     states = list(ts.states)
@@ -52,12 +52,12 @@ def test_func_update_fts(create_solver):
 
 @pytest.mark.parametrize("create_solver", ss.solvers.values())
 def test_cons_rts(create_solver):
-    solver = create_solver()
+    solver = create_solver(False)
     solver, ts = build_simple_ts(solver, c.RelationalTransitionSystem)
 
 @pytest.mark.parametrize("create_solver", ss.solvers.values())
 def test_query_rts(create_solver):
-    solver = create_solver()
+    solver = create_solver(False)
     solver, ts = build_simple_ts(solver, c.RelationalTransitionSystem)
 
     assert len(ts.states) == 2

--- a/tests/python/test_unroller.py
+++ b/tests/python/test_unroller.py
@@ -27,7 +27,7 @@ def get_free_vars(t:ss.Term)->Set[ss.Term]:
 
 @pytest.mark.parametrize("create_solver", ss.solvers.values())
 def test_fts_unroller(create_solver):
-    solver = create_solver()
+    solver = create_solver(False)
     bvsort4 = solver.make_sort(ss.sortkinds.BV, 4)
     bvsort8 = solver.make_sort(ss.sortkinds.BV, 8)
     arrsort = solver.make_sort(ss.sortkinds.ARRAY, bvsort4, bvsort8)
@@ -65,7 +65,7 @@ def test_fts_unroller(create_solver):
 
 @pytest.mark.parametrize("create_solver", ss.solvers.values())
 def test_fts_unroller(create_solver):
-    solver = create_solver()
+    solver = create_solver(False)
     bvsort4 = solver.make_sort(ss.sortkinds.BV, 4)
     bvsort8 = solver.make_sort(ss.sortkinds.BV, 8)
     arrsort = solver.make_sort(ss.sortkinds.ARRAY, bvsort4, bvsort8)

--- a/tests/test_engines.cpp
+++ b/tests/test_engines.cpp
@@ -157,7 +157,7 @@ class InterpWinTests : public ::testing::Test,
  protected:
   void SetUp() override
   {
-    s = ::smt::MsatSolverFactory::create();
+    s = ::smt::MsatSolverFactory::create(false);
     s->set_opt("incremental", "true");
     s->set_opt("produce-models", "true");
     itp = ::smt::MsatSolverFactory::create_interpolating_solver();

--- a/tests/test_engines.cpp
+++ b/tests/test_engines.cpp
@@ -34,7 +34,7 @@ class EngineUnitTests
   void SetUp() override
   {
     std::tuple<SolverEnum, TSEnum> t = GetParam();
-    s = available_solvers().at(std::get<0>(t))();
+    s = available_solvers().at(std::get<0>(t))(false);
     s->set_opt("incremental", "true");
     s->set_opt("produce-models", "true");
 

--- a/tests/test_ts.cpp
+++ b/tests/test_ts.cpp
@@ -22,7 +22,7 @@ class TSUnitTests : public ::testing::Test,
  protected:
   void SetUp() override
   {
-    s = available_solvers().at(GetParam())();
+    s = available_solvers().at(GetParam())(false);
     bvsort = s->make_sort(BV, 8);
   }
   SmtSolver s;

--- a/tests/test_unroller.cpp
+++ b/tests/test_unroller.cpp
@@ -22,7 +22,7 @@ class UnrollerUnitTests : public ::testing::Test,
 protected:
   void SetUp() override
   {
-    s = available_solvers().at(GetParam())();
+    s = available_solvers().at(GetParam())(false);
     bvsort = s->make_sort(BV, 8);
   }
   SmtSolver s;

--- a/travis-scripts/setup-msat.sh
+++ b/travis-scripts/setup-msat.sh
@@ -1,0 +1,73 @@
+#!/bin/bash
+
+DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
+DEPS=$DIR/../deps
+
+mkdir -p $DEPS
+
+
+usage () {
+    cat <<EOF
+Usage: $0 [<option> ...]
+
+Downloads the MathSAT SMT Solver. Note this solver is under a custom (non BSD compliant) license.
+
+-h, --help              display this message and exit
+-y, --auto-yes          automatically agree to conditions (default: off)
+EOF
+    exit 0
+}
+
+get_msat=default
+
+while [ $# -gt 0 ]
+do
+    case $1 in
+        -h|--help) usage;;
+        -y|--auto-yes) get_msat=y;;
+        *) die "unexpected argument: $1";;
+    esac
+    shift
+done
+
+if [[ "$get_msat" == default ]]; then
+    read -p "MathSAT is distributed under a custom (non-BSD compliant) license. By continuing you acknowledge this distinction and assume responsibility for meeting the license conditions. Continue? [y]es/[n]o: " get_msat
+fi
+
+if [[ "$get_msat" != y ]]; then
+    echo "Not downloading MathSAT"
+    exit 0
+fi
+
+if [ ! -d "$DEPS/mathsat" ]; then
+    cd $DEPS
+    mkdir mathsat
+    if [[ "$OSTYPE" == linux* ]]; then
+        wget -O mathsat.tar.gz https://mathsat.fbk.eu/download.php?file=mathsat-5.6.3-linux-x86_64.tar.gz
+    elif [[ "$OSTYPE" == darwin* ]]; then
+        wget -O mathsat.tar.gz https://mathsat.fbk.eu/download.php?file=mathsat-5.6.3-darwin-libcxx-x86_64.tar.gz
+    elif [[ "$OSTYPE" == msys* ]]; then
+        wget -O mathsat.tar.gz https://mathsat.fbk.eu/download.php?file=mathsat-5.6.3-win64-msvc.zip
+    elif [[ "$OSTYPE" == cygwin* ]]; then
+        wget -O mathsat.tar.gz https://mathsat.fbk.eu/download.php?file=mathsat-5.6.3-linux-x86_64.tar.gz
+    else
+        echo "Unrecognized OSTYPE=$OSTYPE"
+        exit 1
+    fi
+
+    tar -xf mathsat.tar.gz -C mathsat --strip-components 1
+    rm mathsat.tar.gz
+
+else
+    echo "$DEPS/mathsat already exists. If you want to re-download, please remove it manually."
+    exit 1
+fi
+
+if [ -f $DEPS/mathsat/lib/libmathsat.a ] ; then \
+    echo "It appears mathsat was setup successfully into $DEPS/mathsat."
+    echo "You may now install it with make ./configure.sh --msat && cd build && make"
+else
+    echo "Downloading mathsat failed."
+    echo "Please see their website: http://mathsat.fbk.eu/"
+    exit 1
+fi


### PR DESCRIPTION
The `create` function for an SmtSolver now takes a boolean flag telling it whether to log the term DAG structure at the smt-switch level. Additionally, the `setup-msat.sh` script has been removed. Users now need to obtain the libraries themselves and place it into `./deps` at the top level of the cosa2 repository.