### PR TITLE
Only keep variables as keys in the unroller cache

### DIFF
--- a/core/unroller.cpp
+++ b/core/unroller.cpp
@@ -33,6 +33,13 @@ Unroller::~Unroller() {}
 Term Unroller::at_time(const Term & t, unsigned int k)
 {
   UnorderedTermMap & cache = var_cache_at_time(k);
+
+  // if t is a variable, it will be cached
+  auto it = cache.find(t);
+  if (it != cache.end()) {
+    return it->second;
+  }
+
   Term ret = solver_->substitute(t, cache);
   untime_cache_[ret] = t;
 

--- a/core/unroller.cpp
+++ b/core/unroller.cpp
@@ -32,16 +32,9 @@ Unroller::~Unroller() {}
 
 Term Unroller::at_time(const Term & t, unsigned int k)
 {
-  UnorderedTermMap & cache = time_cache_at_time(k);
-
-  auto it = cache.find(t);
-  if (it != cache.end()) {
-    return it->second;
-  }
-
+  UnorderedTermMap & cache = var_cache_at_time(k);
   Term ret = solver_->substitute(t, cache);
   untime_cache_[ret] = t;
-  cache[t] = ret;
 
   return ret;
 }
@@ -73,7 +66,7 @@ Term Unroller::var_at_time(const Term & v, unsigned int k)
   return timed_v;
 }
 
-UnorderedTermMap & Unroller::time_cache_at_time(unsigned int k)
+UnorderedTermMap & Unroller::var_cache_at_time(unsigned int k)
 {
   while (time_cache_.size() <= k) {
     time_cache_.push_back(UnorderedTermMap());

--- a/core/unroller.h
+++ b/core/unroller.h
@@ -41,7 +41,7 @@ class Unroller
 
  private:
   smt::Term var_at_time(const smt::Term & v, unsigned int k);
-  smt::UnorderedTermMap & time_cache_at_time(unsigned int k);
+  smt::UnorderedTermMap & var_cache_at_time(unsigned int k);
 
   const TransitionSystem & ts_;
   smt::SmtSolver & solver_;


### PR DESCRIPTION
All right, so @lonsing and I, with lots of help from the boolector developers have been looking into https://github.com/upscale-project/cosa2/issues/36. We're pretty sure that it happens because the boolector `nodemap` which is used in `smt-switch` for the `substitute` function only supports variable -> term substitutions. Because we use the cache in `substitute` in the unroller, this could add non-variables as keys which could cause problems. I added an assertion checking this in `smt-switch` and then made this change so that the cache is always over variables.

Note, one alternative is to not use `nodemap` for substitution, instead relying on the `smt-switch` implementation of `substitute`. However, I would expect that to be much slower because it involves unpacking all the wrapped objects at each subterm. I think the main purpose of the cache was for quick look ups of variables (which still happens), so this fix makes sense to me. What do you guys think?

@lonsing would it be difficult for you to port this change to your setup for reproducing the bug and make sure that it fixes it there also? I checked using the latest versions of everything.