### PR TITLE
Solve in a new context for each engine

### DIFF
--- a/engines/bmc.cpp
+++ b/engines/bmc.cpp
@@ -42,11 +42,16 @@ void Bmc::initialize()
 
 ProverResult Bmc::check_until(int k)
 {
+  // keep the solver instance clean by checking in a different context
+  solver_->push();
   for (int i = 0; i <= k; ++i) {
     if (!step(i)) {
+      compute_witness();
+      solver_->pop();
       return ProverResult::FALSE;
     }
   }
+  solver_->pop();
   return ProverResult::UNKNOWN;
 }
 

--- a/engines/bmc_simplepath.cpp
+++ b/engines/bmc_simplepath.cpp
@@ -32,16 +32,22 @@ BmcSimplePath::~BmcSimplePath() {}
 
 ProverResult BmcSimplePath::check_until(int k)
 {
+  // keep the solver instance clean by checking in a different context
+  solver_->push();
   for (int i = 0; i <= k; ++i) {
     logger.log(1, "Checking Bmc at bound: {}", i);
     if (!base_step(i)) {
+      compute_witness();
+      solver_->pop();
       return ProverResult::FALSE;
     }
     logger.log(1, "Checking simple path at bound: {}", i);
     if (cover_step(i)) {
+      solver_->pop();
       return ProverResult::TRUE;
     }
   }
+  solver_->pop();
   return ProverResult::UNKNOWN;
 }
 

--- a/engines/interpolantmc.cpp
+++ b/engines/interpolantmc.cpp
@@ -84,10 +84,15 @@ void InterpolantMC::initialize()
 ProverResult InterpolantMC::check_until(int k)
 {
   try {
+    // keep the solver instance clean by checking in a different context
+    solver_->push();
     for (int i = 0; i <= k; ++i) {
       if (step(i)) {
+        solver_->pop();
         return ProverResult::TRUE;
       } else if (concrete_cex_) {
+        compute_witness();
+        solver_->pop();
         return ProverResult::FALSE;
       }
     }
@@ -95,6 +100,7 @@ ProverResult InterpolantMC::check_until(int k)
   catch (InternalSolverException & e) {
     logger.log(1, "Failed when computing interpolant.");
   }
+  solver_->pop();
   return ProverResult::UNKNOWN;
 }
 

--- a/engines/kinduction.cpp
+++ b/engines/kinduction.cpp
@@ -45,16 +45,22 @@ void KInduction::initialize()
 
 ProverResult KInduction::check_until(int k)
 {
+  // keep the solver instance clean by checking in a different context
+  solver_->push();
   for (int i = 0; i <= k; ++i) {
     logger.log(1, "Checking k-induction base case at bound: {}", i);
     if (!base_step(i)) {
+      compute_witness();
+      solver_->pop();
       return ProverResult::FALSE;
     }
     logger.log(1, "Checking k-induction inductive step at bound: {}", i);
     if (inductive_step(i)) {
+      solver_->pop();
       return ProverResult::TRUE;
     }
   }
+  solver_->pop();
   return ProverResult::UNKNOWN;
 }
 

--- a/engines/prover.cpp
+++ b/engines/prover.cpp
@@ -43,11 +43,19 @@ ProverResult Prover::prove() { return check_until(INT_MAX); }
 
 bool Prover::witness(std::vector<UnorderedTermMap> & out)
 {
+  for (auto time_step_map : witness_) {
+    out.push_back(time_step_map);
+  }
+  return true;
+}
+
+bool Prover::compute_witness()
+{
   // TODO: make sure the solver state is SAT
 
   for (int i = 0; i <= reached_k_; ++i) {
-    out.push_back(UnorderedTermMap());
-    UnorderedTermMap & map = out.back();
+    witness_.push_back(UnorderedTermMap());
+    UnorderedTermMap & map = witness_.back();
 
     for (auto v : ts_.states()) {
       Term vi = unroller_.at_time(v, i);

--- a/engines/prover.h
+++ b/engines/prover.h
@@ -48,5 +48,9 @@ class Prover
   int reached_k_;
 
   smt::Term bad_;
+
+  std::vector<smt::UnorderedTermMap> witness_;
+
+  bool compute_witness();
 };
 }  // namespace cosa


### PR DESCRIPTION
 This PR pushes a new context in each engine to keep solver instance clean even when reset_assertions not supported. This also requires computing the witness preemptively, because we cannot get values after popping a context.

The main motivation for this PR is that there are users that plan to interact with the API soon (as a backend for https://github.com/leonardt/fault. I don't want them to have to worry about polluting the solver if they try calls to multiple engines in the same session. Since some solvers don't have `reset_assertions`, the easiest thing to do is to solve in a separate context.

I'm running jobs now to compare performance. If it's not a major performance hit, I think this makes sense. I'll update this PR with results when I have them. In the future, we can think about other alternatives, such as translating terms to a different solver instance first.