### PR TITLE
API Update. Rename: inputs->inputvars, states->statevars

### DIFF
--- a/core/prop.cpp
+++ b/core/prop.cpp
@@ -26,7 +26,7 @@ namespace cosa {
 Property::Property(const TransitionSystem & ts, const Term & p)
     : ts_(ts), prop_(p)
 {
-  const UnorderedTermSet & states = ts.states();
+  const UnorderedTermSet & states = ts.statevars();
   UnorderedTermSet free_symbols = get_free_symbols(p);
   for (auto s : free_symbols) {
     if (states.find(s) == states.end()) {

--- a/core/ts.cpp
+++ b/core/ts.cpp
@@ -105,14 +105,14 @@ void TransitionSystem::name_term(const string name, const Term & t)
   named_terms_[name] = t;
 }
 
-Term TransitionSystem::make_input(const string name, const Sort & sort)
+Term TransitionSystem::make_inputvar(const string name, const Sort & sort)
 {
   Term input = solver_->make_symbol(name, sort);
   inputs_.insert(input);
   return input;
 }
 
-Term TransitionSystem::make_state(const string name, const Sort & sort)
+Term TransitionSystem::make_statevar(const string name, const Sort & sort)
 {
   Term state = solver_->make_symbol(name, sort);
   Term next_state = solver_->make_symbol(name + ".next", sort);

--- a/core/ts.h
+++ b/core/ts.h
@@ -89,7 +89,7 @@ class TransitionSystem
    * @param sort the sort of the input
    * @return the input term
    */
-  smt::Term make_input(const std::string name, const smt::Sort & sort);
+  smt::Term make_inputvar(const std::string name, const smt::Sort & sort);
 
   /* Create an state of a given sort
    * @param name the name of the state
@@ -98,7 +98,7 @@ class TransitionSystem
    *
    * Can get next state var with next(const smt::Term t)
    */
-  smt::Term make_state(const std::string name, const smt::Sort & sort);
+  smt::Term make_statevar(const std::string name, const smt::Sort & sort);
 
   /* Map all next state variables to current state variables in the term
    * @param t the term to map
@@ -129,9 +129,9 @@ class TransitionSystem
   // getters
   smt::SmtSolver & solver() { return solver_; };
 
-  const smt::UnorderedTermSet & states() const { return states_; };
+  const smt::UnorderedTermSet & statevars() const { return states_; };
 
-  const smt::UnorderedTermSet & inputs() const { return inputs_; };
+  const smt::UnorderedTermSet & inputvars() const { return inputs_; };
 
   /* Returns the initial state constraints
    * @return a boolean term constraining the initial state

--- a/core/unroller.cpp
+++ b/core/unroller.cpp
@@ -78,14 +78,14 @@ UnorderedTermMap & Unroller::var_cache_at_time(unsigned int k)
     UnorderedTermMap & subst = time_cache_.back();
     const unsigned int t = time_cache_.size() - 1;
 
-    for (auto v : ts_.states()) {
+    for (auto v : ts_.statevars()) {
       Term vn = ts_.next(v);
       Term new_v = var_at_time(v, t);
       Term new_vn = var_at_time(v, t + 1);
       subst[v] = new_v;
       subst[vn] = new_vn;
     }
-    for (auto v : ts_.inputs()) {
+    for (auto v : ts_.inputvars()) {
       Term new_v = var_at_time(v, t);
       subst[v] = new_v;
     }

--- a/engines/bmc_simplepath.cpp
+++ b/engines/bmc_simplepath.cpp
@@ -57,7 +57,7 @@ bool BmcSimplePath::cover_step(int i)
   for (int j = 1; j <= i; ++j) {
     solver_->assert_formula(unroller_.at_time(not_init, j));
   }
-  if (ts_.states().size() &&check_simple_path_lazy(i)) {
+  if (ts_.statevars().size() && check_simple_path_lazy(i)) {
     return true;
   }
   solver_->pop();

--- a/engines/interpolantmc.cpp
+++ b/engines/interpolantmc.cpp
@@ -44,11 +44,11 @@ void InterpolantMC::initialize()
   // B)
   UnorderedTermMap & cache = to_solver_.get_cache();
   Term tmp1;
-  for (auto s : ts_.states()) {
+  for (auto s : ts_.statevars()) {
     tmp1 = unroller_.at_time(s, 1);
     cache[to_interpolator_.transfer_term(tmp1)] = tmp1;
   }
-  for (auto i : ts_.inputs()) {
+  for (auto i : ts_.inputvars()) {
     tmp1 = unroller_.at_time(i, 1);
     cache[to_interpolator_.transfer_term(tmp1)] = tmp1;
   }
@@ -66,11 +66,11 @@ void InterpolantMC::initialize()
   }
 
   // populate map from time 1 to time 0
-  for (auto s : ts_.states()) {
+  for (auto s : ts_.statevars()) {
     Term s0 = unroller_.at_time(s, 0);
   }
 
-  for (auto i : ts_.inputs()) {
+  for (auto i : ts_.inputvars()) {
     Term i0 = unroller_.at_time(i, 0);
   }
 

--- a/engines/kinduction.cpp
+++ b/engines/kinduction.cpp
@@ -90,7 +90,7 @@ bool KInduction::inductive_step(int i)
   solver_->assert_formula(simple_path_);
   solver_->assert_formula(unroller_.at_time(bad_, i + 1));
 
-  if (ts_.states().size() && check_simple_path_lazy(i + 1)) {
+  if (ts_.statevars().size() && check_simple_path_lazy(i + 1)) {
     return true;
   }
 
@@ -103,10 +103,10 @@ bool KInduction::inductive_step(int i)
 
 Term KInduction::simple_path_constraint(int i, int j)
 {
-  assert(ts_.states().size());
+  assert(ts_.statevars().size());
 
   Term disj = false_;
-  for (auto v : ts_.states()) {
+  for (auto v : ts_.statevars()) {
     Term vi = unroller_.at_time(v, i);
     Term vj = unroller_.at_time(v, j);
     Term eq = solver_->make_term(PrimOp::Equal, vi, vj);

--- a/engines/prover.cpp
+++ b/engines/prover.cpp
@@ -49,13 +49,13 @@ bool Prover::witness(std::vector<UnorderedTermMap> & out)
     out.push_back(UnorderedTermMap());
     UnorderedTermMap & map = out.back();
 
-    for (auto v : ts_.states()) {
+    for (auto v : ts_.statevars()) {
       Term vi = unroller_.at_time(v, i);
       Term r = solver_->get_value(vi);
       map[v] = r;
     }
 
-    for (auto v : ts_.inputs()) {
+    for (auto v : ts_.inputvars()) {
       Term vi = unroller_.at_time(v, i);
       Term r = solver_->get_value(vi);
       map[v] = r;

--- a/examples/python-api/simple_alu.py
+++ b/examples/python-api/simple_alu.py
@@ -20,13 +20,13 @@ def build_simple_alu_fts(s:ss.SmtSolver)->cosa2.Property:
     bvsort8 = s.make_sort(BV, 8)
 
     # Create the states
-    cfg = fts.make_state('cfg', bvsort1)
-    spec_res = fts.make_state('spec_res', bvsort8)
-    imp_res  = fts.make_state('imp_res', bvsort8)
+    cfg = fts.make_statevar('cfg', bvsort1)
+    spec_res = fts.make_statevar('spec_res', bvsort8)
+    imp_res  = fts.make_statevar('imp_res', bvsort8)
 
     # Create the inputs
-    a = fts.make_input('a', bvsort8)
-    b = fts.make_input('b', bvsort8)
+    a = fts.make_inputvar('a', bvsort8)
+    b = fts.make_inputvar('b', bvsort8)
 
     # Add logic for cfg
     ## Start at 0

--- a/frontends/btor2_encoder.cpp
+++ b/frontends/btor2_encoder.cpp
@@ -295,7 +295,7 @@ void BTOR2Encoder::parse(const std::string filename)
           symbol_ = "state" + to_string(l_->id);
       }
 
-      Term state = ts_.make_state(symbol_, linesort_);
+      Term state = ts_.make_statevar(symbol_, linesort_);
       terms_[l_->id] = state;
       statesvec_.push_back(state);
       // will be removed from this map if there's a next function for this state
@@ -308,7 +308,7 @@ void BTOR2Encoder::parse(const std::string filename)
       } else {
         symbol_ = "input" + to_string(l_->id);
       }
-      Term input = ts_.make_input(symbol_, linesort_);
+      Term input = ts_.make_inputvar(symbol_, linesort_);
       terms_[l_->id] = input;
       inputsvec_.push_back(input);
     } else if (l_->tag == BTOR2_TAG_output) {
@@ -396,7 +396,7 @@ void BTOR2Encoder::parse(const std::string filename)
     } else if (l_->tag == BTOR2_TAG_bad) {
       Term bad = bv_to_bool(termargs_[0]);
       UnorderedTermSet free_symbols = get_free_symbols(bad);
-      const UnorderedTermSet & states = ts_.states();
+      const UnorderedTermSet & states = ts_.statevars();
 
       bool need_witness = false;
       for (auto s : free_symbols) {
@@ -408,8 +408,8 @@ void BTOR2Encoder::parse(const std::string filename)
 
       if (need_witness) {
         Term witness =
-            ts_.make_state("witness_" + std::to_string(witness_id_++),
-                           solver_->make_sort(BOOL));
+            ts_.make_statevar("witness_" + std::to_string(witness_id_++),
+                              solver_->make_sort(BOOL));
         ts_.constrain_init(witness);
         ts_.assign_next(witness, solver_->make_term(Not, bad));
         propvec_.push_back(witness);

--- a/frontends/btor2_encoder.h
+++ b/frontends/btor2_encoder.h
@@ -49,7 +49,7 @@ class BTOR2Encoder
   const smt::TermVec & fairvec() const { return fairvec_; };
   const smt::TermVec & inputsvec() const { return inputsvec_; }
   const smt::TermVec & statesvec() const { return statesvec_; }
-  const std::map<uint64_t, smt::Term> & no_next_states() const
+  const std::map<uint64_t, smt::Term> & no_next_statevars() const
   {
     return no_next_states_;
   }

--- a/frontends/smvparser.y
+++ b/frontends/smvparser.y
@@ -176,7 +176,7 @@ ivar_list:
     complex_identifier ":" type_identifier ";" {
          //cout <<"find an ivar"<<endl;
          SMVnode *a = $3;
-         smt::Term input = enc.rts_.make_input($1, a->getSort());
+         smt::Term input = enc.rts_.make_inputvar($1, a->getSort());
          enc.terms_[$1] = input;
     };
 
@@ -187,7 +187,7 @@ var_test:
 var_list:
     complex_identifier ":" type_identifier ";"{
          SMVnode *a = $3;
-         smt::Term state = enc.rts_.make_state($1, a->getSort());
+         smt::Term state = enc.rts_.make_statevar($1, a->getSort());
          enc.terms_[$1] = state;
          //cout<<"find a var" <<endl;
     };
@@ -199,7 +199,7 @@ frozenvar_test:
 frozenvar_list:
   complex_identifier ":" type_identifier ";" {
       SMVnode *a = $3;
-      smt::Term state = enc.rts_.make_state($1, a->getSort());
+      smt::Term state = enc.rts_.make_statevar($1, a->getSort());
       enc.terms_[$1] = state;
       smt::Term n = enc.rts_.next(state);
       smt::Term e = enc.solver_->make_term(smt::Equal, n, state);

--- a/printers/btor2_witness_printer.h
+++ b/printers/btor2_witness_printer.h
@@ -182,7 +182,7 @@ void print_witness_btor(const BTOR2Encoder & btor_enc,
   const smt::TermVec inputs = btor_enc.inputsvec();
   const smt::TermVec states = btor_enc.statesvec();
   const std::map<uint64_t, smt::Term> no_next_states =
-      btor_enc.no_next_states();
+      btor_enc.no_next_statevars();
   bool has_states_without_next = no_next_states.size();
 
   logger.log(0, "#0");

--- a/printers/vcd_witness_printer.cpp
+++ b/printers/vcd_witness_printer.cpp
@@ -155,8 +155,8 @@ static std::string as_decimal(std::string val)
 
 VCDWitnessPrinter::VCDWitnessPrinter(
     const TransitionSystem & ts, const std::vector<smt::UnorderedTermMap> & cex)
-    : inputs_(ts.inputs()),
-      states_(ts.states()),
+    : inputs_(ts.inputvars()),
+      states_(ts.statevars()),
       named_terms_(ts.named_terms()),
       cex_(cex),
       hash_id_cnt_(0)

--- a/python/cosa2_imp.pxd
+++ b/python/cosa2_imp.pxd
@@ -18,15 +18,15 @@ cdef extern from "core/ts.h" namespace "cosa":
         void constrain_inputs(const c_Term & constraint) except +
         void add_constraint(const c_Term & constraint) except +
         void name_term(const string name, const c_Term & t) except +
-        c_Term make_input(const string name, const c_Sort & sort) except +
-        c_Term make_state(const string name, const c_Sort & sort) except +
+        c_Term make_inputvar(const string name, const c_Sort & sort) except +
+        c_Term make_statevar(const string name, const c_Sort & sort) except +
         c_Term curr(const c_Term & term) except +
         c_Term next(const c_Term & term) except +
         bint is_curr_var(const c_Term & sv) except +
         bint is_next_var(const c_Term & sv) except +
         c_SmtSolver & solver() except +
-        const c_UnorderedTermSet & states() except +
-        const c_UnorderedTermSet & inputs() except +
+        const c_UnorderedTermSet & statevars() except +
+        const c_UnorderedTermSet & inputvars() except +
         c_Term init() except +
         c_Term trans() except +
         const c_UnorderedTermMap & state_updates() except +

--- a/python/cosa2_imp.pxi
+++ b/python/cosa2_imp.pxi
@@ -66,14 +66,14 @@ cdef class __AbstractTransitionSystem:
     def name_term(self, str name, Term t):
         dref(self.cts).name_term(name.encode(), t.ct)
 
-    def make_input(self, str name, Sort sort):
+    def make_inputvar(self, str name, Sort sort):
         cdef Term term = Term(self._solver)
-        term.ct = dref(self.cts).make_input(name.encode(), sort.cs)
+        term.ct = dref(self.cts).make_inputvar(name.encode(), sort.cs)
         return term
 
-    def make_state(self, str name, Sort sort):
+    def make_statevar(self, str name, Sort sort):
         cdef Term term = Term(self._solver)
-        term.ct = dref(self.cts).make_state(name.encode(), sort.cs)
+        term.ct = dref(self.cts).make_statevar(name.encode(), sort.cs)
         return term
 
     def curr(self, Term t):
@@ -100,7 +100,7 @@ cdef class __AbstractTransitionSystem:
     def states(self):
         states_set = set()
 
-        cdef const_UnorderedTermSetPtr c_states_set = &dref(self.cts).states()
+        cdef const_UnorderedTermSetPtr c_states_set = &dref(self.cts).statevars()
         cdef c_UnorderedTermSet_const_iterator it = c_states_set.const_begin()
         cdef c_UnorderedTermSet_const_iterator e  = c_states_set.const_end()
 
@@ -117,7 +117,7 @@ cdef class __AbstractTransitionSystem:
     def inputs(self):
         inputs_set = set()
 
-        cdef const_UnorderedTermSetPtr c_inputs_set = &dref(self.cts).inputs()
+        cdef const_UnorderedTermSetPtr c_inputs_set = &dref(self.cts).inputvars()
         cdef c_UnorderedTermSet_const_iterator it = c_inputs_set.const_begin()
         cdef c_UnorderedTermSet_const_iterator e  = c_inputs_set.const_end()
 

--- a/tests/python/test_engines.py
+++ b/tests/python/test_engines.py
@@ -20,13 +20,13 @@ def build_simple_alu_fts(s:ss.SmtSolver)->c.Property:
     bvsort8 = s.make_sort(BV, 8)
 
     # Create the states
-    cfg = fts.make_state('cfg', bvsort1)
-    spec_res = fts.make_state('spec_res', bvsort8)
-    imp_res  = fts.make_state('imp_res', bvsort8)
+    cfg = fts.make_statevar('cfg', bvsort1)
+    spec_res = fts.make_statevar('spec_res', bvsort8)
+    imp_res  = fts.make_statevar('imp_res', bvsort8)
 
     # Create the inputs
-    a = fts.make_input('a', bvsort8)
-    b = fts.make_input('b', bvsort8)
+    a = fts.make_inputvar('a', bvsort8)
+    b = fts.make_inputvar('b', bvsort8)
 
     # Add logic for cfg
     ## Start at 0

--- a/tests/python/test_ts.py
+++ b/tests/python/test_ts.py
@@ -6,8 +6,8 @@ def build_simple_ts(solver, TS):
     bvsort = solver.make_sort(ss.sortkinds.BV, 8)
 
     ts = TS(solver)
-    x = ts.make_state('x', bvsort)
-    y = ts.make_state('y', bvsort)
+    x = ts.make_statevar('x', bvsort)
+    y = ts.make_statevar('y', bvsort)
     xp1 = solver.make_term(ss.primops.BVAdd, x, solver.make_term(1, bvsort))
     ts.name_term('xp1', xp1)
     ts.assign_next(x, xp1)

--- a/tests/python/test_unroller.py
+++ b/tests/python/test_unroller.py
@@ -33,8 +33,8 @@ def test_fts_unroller(create_solver):
     arrsort = solver.make_sort(ss.sortkinds.ARRAY, bvsort4, bvsort8)
 
     ts = c.FunctionalTransitionSystem(solver)
-    x = ts.make_state('x', bvsort4)
-    mem = ts.make_state('mem', arrsort)
+    x = ts.make_statevar('x', bvsort4)
+    mem = ts.make_statevar('mem', arrsort)
 
     u = c.Unroller(ts, solver)
 
@@ -71,8 +71,8 @@ def test_fts_unroller(create_solver):
     arrsort = solver.make_sort(ss.sortkinds.ARRAY, bvsort4, bvsort8)
 
     ts = c.RelationalTransitionSystem(solver)
-    x = ts.make_state('x', bvsort4)
-    mem = ts.make_state('mem', arrsort)
+    x = ts.make_statevar('x', bvsort4)
+    mem = ts.make_statevar('mem', arrsort)
 
     u = c.Unroller(ts, solver)
 

--- a/tests/test_engines.cpp
+++ b/tests/test_engines.cpp
@@ -48,7 +48,7 @@ class EngineUnitTests
     bvsort8 = s->make_sort(BV, 8);
 
     // "Hello, World"-style counter test
-    Term cnt = ts->make_state("cnt", bvsort8);
+    Term cnt = ts->make_statevar("cnt", bvsort8);
     ts->set_init(s->make_term(Equal, cnt, s->make_term(0, bvsort8)));
     ts->assign_next(
         cnt,
@@ -173,11 +173,11 @@ class InterpWinTests : public ::testing::Test,
     bvsort8 = s->make_sort(BV, 8);
 
     // Simple non-inductive system/property
-    Term cfg = ts->make_state("cfg", boolsort);
-    Term a = ts->make_input("a", bvsort8);
-    Term b = ts->make_input("b", bvsort8);
-    Term initstate = ts->make_state("initstate", boolsort);
-    Term out = ts->make_state("out", bvsort8);
+    Term cfg = ts->make_statevar("cfg", boolsort);
+    Term a = ts->make_inputvar("a", bvsort8);
+    Term b = ts->make_inputvar("b", bvsort8);
+    Term initstate = ts->make_statevar("initstate", boolsort);
+    Term out = ts->make_statevar("out", bvsort8);
     ts->add_constraint(s->make_term(
         Equal,
         out,
@@ -193,7 +193,7 @@ class InterpWinTests : public ::testing::Test,
         s->make_term(Implies,
                      s->make_term(Not, initstate),
                      s->make_term(Equal, out, s->make_term(BVAdd, a, b)));
-    Term witness = ts->make_state("witness", boolsort);
+    Term witness = ts->make_statevar("witness", boolsort);
     ts->constrain_init(witness);
     ts->assign_next(witness, prop);
     true_p = new Property(*ts, witness);

--- a/tests/test_ts.cpp
+++ b/tests/test_ts.cpp
@@ -44,7 +44,7 @@ TEST_P(TSUnitTests, RTS_IsFunc)
 TEST_P(TSUnitTests, FTS_Exceptions)
 {
   FunctionalTransitionSystem fts(s);
-  Term x = fts.make_state("x", bvsort);
+  Term x = fts.make_statevar("x", bvsort);
   Term xp1_n = fts.next(s->make_term(BVAdd, x, s->make_term(1, bvsort)));
   ASSERT_THROW(fts.assign_next(x, xp1_n), CosaException);
 }
@@ -52,7 +52,7 @@ TEST_P(TSUnitTests, FTS_Exceptions)
 TEST_P(TSUnitTests, RTS_Exceptions)
 {
   RelationalTransitionSystem rts(s);
-  Term x = rts.make_state("x", bvsort);
+  Term x = rts.make_statevar("x", bvsort);
   Term xp1_n = rts.next(s->make_term(BVAdd, x, s->make_term(1, bvsort)));
   ASSERT_THROW(rts.assign_next(x, xp1_n), CosaException);
   ASSERT_NO_THROW(rts.constrain_trans(s->make_term(Equal, rts.next(x), xp1_n)));

--- a/tests/test_unroller.cpp
+++ b/tests/test_unroller.cpp
@@ -32,7 +32,7 @@ protected:
 TEST_P(UnrollerUnitTests, FTS_Unroll)
 {
   FunctionalTransitionSystem fts(s);
-  Term x = fts.make_state("x", bvsort);
+  Term x = fts.make_statevar("x", bvsort);
   fts.assign_next(x, s->make_term(BVAdd, x, s->make_term(1, bvsort)));
 
   Unroller u(fts, s);
@@ -43,7 +43,7 @@ TEST_P(UnrollerUnitTests, FTS_Unroll)
 TEST_P(UnrollerUnitTests, RTS_Unroll)
 {
   RelationalTransitionSystem rts(s);
-  Term x = rts.make_state("x", bvsort);
+  Term x = rts.make_statevar("x", bvsort);
   rts.assign_next(x, s->make_term(BVAdd, x, s->make_term(1, bvsort)));
 
   Unroller u(rts, s);


### PR DESCRIPTION
As discussed offline, we're updating the API to use the more accurate `statevars` and `inputvars` instead of `states` and `inputs`.